### PR TITLE
Add Query support to VirtualMachine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/Azure/go-autorest/autorest v0.9.0
 	github.com/Azure/go-autorest/autorest/date v0.2.0
-	github.com/microsoft/moc v0.10.4
+	github.com/microsoft/moc v0.10.5-alpha.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/viper v1.6.2
 	google.golang.org/grpc v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
@@ -103,6 +104,8 @@ github.com/microsoft/moc v0.10.1-alpha.4 h1:5P6UR+2kq+X9dsjVA2OBDPLNBg0YOgGsqqUR
 github.com/microsoft/moc v0.10.1-alpha.4/go.mod h1:oK8iLrb4IOdvmokCAgbMWzPj2m7PcARZnCa3g3tNrFI=
 github.com/microsoft/moc v0.10.4 h1:bgZCdRhY2YEzTLjZrrueeMZFm5NFzvq9VQuDFA30XaQ=
 github.com/microsoft/moc v0.10.4/go.mod h1:drS7YrfMSpBkhkOmGOXusIAniGCtbT08BbVF9sEyTS0=
+github.com/microsoft/moc v0.10.5-alpha.1 h1:iS4UitVEUIki7EoyCnHEWu/3IaHIpc9kNFsxRSu+8ZM=
+github.com/microsoft/moc v0.10.5-alpha.1/go.mod h1:drS7YrfMSpBkhkOmGOXusIAniGCtbT08BbVF9sEyTS0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/services/compute/virtualmachine/client.go
+++ b/services/compute/virtualmachine/client.go
@@ -17,6 +17,7 @@ type Service interface {
 	Get(context.Context, string, string) (*[]compute.VirtualMachine, error)
 	CreateOrUpdate(context.Context, string, string, *compute.VirtualMachine) (*compute.VirtualMachine, error)
 	Delete(context.Context, string, string) error
+	Query(context.Context, string, string) (*[]compute.VirtualMachine, error)
 	Start(context.Context, string, string) error
 	Stop(context.Context, string, string) error
 }
@@ -48,6 +49,11 @@ func (c *VirtualMachineClient) CreateOrUpdate(ctx context.Context, group, name s
 // Delete methods invokes delete of the compute resource
 func (c *VirtualMachineClient) Delete(ctx context.Context, group string, name string) error {
 	return c.internal.Delete(ctx, group, name)
+}
+
+// Query method invokes the client Get method and uses the provided query to filter the returned results
+func (c *VirtualMachineClient) Query(ctx context.Context, group, query string) (*[]compute.VirtualMachine, error) {
+	return c.internal.Query(ctx, group, query)
 }
 
 // Start the Virtual Machine

--- a/services/compute/virtualmachine/wssd.go
+++ b/services/compute/virtualmachine/wssd.go
@@ -6,8 +6,11 @@ package virtualmachine
 import (
 	"context"
 	"fmt"
+
 	"github.com/microsoft/moc-sdk-for-go/services/compute"
 	"github.com/microsoft/moc/pkg/auth"
+	"github.com/microsoft/moc/pkg/config"
+	"github.com/microsoft/moc/pkg/marshal"
 
 	wssdcloudproto "github.com/microsoft/moc/rpc/common"
 
@@ -89,6 +92,26 @@ func (c *client) Delete(ctx context.Context, group, name string) error {
 	_, err = c.VirtualMachineAgentClient.Invoke(ctx, request)
 
 	return err
+}
+
+// Query
+func (c *client) Query(ctx context.Context, group, query string) (*[]compute.VirtualMachine, error) {
+	vms, err := c.Get(ctx, group, "")
+	if err != nil {
+		return nil, err
+	}
+
+	filteredBytes, err := config.MarshalOutput(*vms, query, "yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	err = marshal.FromYAMLBytes(filteredBytes, vms)
+	if err != nil {
+		return nil, err
+	}
+
+	return vms, nil
 }
 
 // Stop


### PR DESCRIPTION
We need to allow SDK callers such as CSI, MOC Cloud Provider, etc to be able to query cloudagent entities by arbitrary properties. For example, we should be able to 'get' VM's by computername or vmsize etc.

MOC already exposes a nice query functionality that the CTL uses today. I've raised a PR to update moc to expose that query functionality for the SDK to leverage too (https://github.com/microsoft/moc/pull/11). 

This PR updates the SDK to expose a Query function from computer.VirtualMachine that uses this updated moc code. End experience would be for a SDK caller to be able to do something like the following to get VMs by vmsize:

`vmclient.Query(ctx, group, "[?virtualmachineproperties.hardwareprofile.vmsize=='Standard_A4_v2']")
`
We can also then add Query function to any other SDK entity which wants to expose it, as needed.
