### PR TITLE
Query should use JSON marshaler

### DIFF
--- a/services/compute/virtualmachine/wssd.go
+++ b/services/compute/virtualmachine/wssd.go
@@ -101,12 +101,13 @@ func (c *client) Query(ctx context.Context, group, query string) (*[]compute.Vir
 		return nil, err
 	}
 
-	filteredBytes, err := config.MarshalOutput(*vms, query, "yaml")
+	filteredBytes, err := config.MarshalOutput(*vms, query, "json")
 	if err != nil {
 		return nil, err
 	}
+	fmt.Printf("ITS: %s\n", string(filteredBytes))
 
-	err = marshal.FromYAMLBytes(filteredBytes, vms)
+	err = marshal.FromJSONBytes(filteredBytes, vms)
 	if err != nil {
 		return nil, err
 	}

--- a/services/compute/virtualmachine/wssd.go
+++ b/services/compute/virtualmachine/wssd.go
@@ -105,7 +105,6 @@ func (c *client) Query(ctx context.Context, group, query string) (*[]compute.Vir
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("ITS: %s\n", string(filteredBytes))
 
 	err = marshal.FromJSONBytes(filteredBytes, vms)
 	if err != nil {


### PR DESCRIPTION
Using the YAML marshaler is not safe in this case as some property names within our structs have a mix of uppercase/lowercase. Converting to YAML bytes and then back will cause data loss (the mixed case properties will be dropped). JSON handles this case much better.