### PR TITLE
Changes for static ip

### DIFF
--- a/services/compute/virtualmachine/virtualmachine.go
+++ b/services/compute/virtualmachine/virtualmachine.go
@@ -242,14 +242,14 @@ func (c *client) getWssdVirtualMachineOSConfiguration(s *compute.OSProfile) (*ws
 
 	switch s.OsType {
 	case compute.Linux:
-		osType = wssdcommon.OperatingSystemType_LINUX
+		osconfig.Ostype = wssdcommon.OperatingSystemType_LINUX
 	case compute.Windows:
-		osType = wssdcommon.OperatingSystemType_WINDOWS
+		osconfig.Ostype = wssdcommon.OperatingSystemType_WINDOWS
 	default:
 		if s.LinuxConfiguration != nil {
-			osType = wssdcommon.OperatingSystemType_LINUX
+			osconfig.Ostype = wssdcommon.OperatingSystemType_LINUX
 		} else {
-			osType = wssdcommon.OperatingSystemType_WINDOWS
+			osconfig.Ostype = wssdcommon.OperatingSystemType_WINDOWS
 		}
 	}
 

--- a/services/network/virtualnetwork/virtualnetwork.go
+++ b/services/network/virtualnetwork/virtualnetwork.go
@@ -44,6 +44,12 @@ func getWssdVirtualNetwork(c *network.VirtualNetwork, groupName string) (*wssdcl
 		if c.VirtualNetworkPropertiesFormat.MacPoolName != nil {
 			wssdnetwork.MacPoolName = *c.VirtualNetworkPropertiesFormat.MacPoolName
 		}
+
+		if c.DhcpOptions != nil && c.DhcpOptions.DNSServers != nil {
+			wssdnetwork.Dns = &wssdcommonproto.Dns{
+				Servers: *c.DhcpOptions.DNSServers,
+			}
+		}
 	}
 
 	if c.Type == nil {
@@ -172,6 +178,10 @@ func getWssdNetworkRoutes(routetable *network.RouteTable) (wssdcloudroutes []*ws
 // Conversion function from wssdcloudnetwork to network
 func getVirtualNetwork(c *wssdcloudnetwork.VirtualNetwork, group string) *network.VirtualNetwork {
 	stringType := virtualNetworkTypeToString(c.Type)
+	dnsservers := []string{}
+	if c.Dns != nil {
+		dnsservers = c.Dns.Servers
+	}
 	return &network.VirtualNetwork{
 		Name:     &c.Name,
 		Location: &c.LocationName,
@@ -182,6 +192,9 @@ func getVirtualNetwork(c *wssdcloudnetwork.VirtualNetwork, group string) *networ
 			Subnets:     getNetworkSubnets(c.Subnets),
 			Statuses:    status.GetStatuses(c.GetStatus()),
 			MacPoolName: &c.MacPoolName,
+			DhcpOptions: &network.DhcpOptions{
+				DNSServers: &dnsservers,
+			},
 		},
 	}
 }


### PR DESCRIPTION
1. Passing along dns info.
2. actually setting the ostype (before we were never assigning osType to anything).