### PR TITLE
Adding custom Sku size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/Azure/go-autorest/autorest v0.9.0
 	github.com/Azure/go-autorest/autorest/date v0.2.0
-	github.com/microsoft/moc v0.10.6-alpha.6
+	github.com/microsoft/moc v0.10.6-alpha.7
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/viper v1.6.2
 	google.golang.org/grpc v1.27.1

--- a/services/compute/compute.go
+++ b/services/compute/compute.go
@@ -163,8 +163,15 @@ type OSProfile struct {
 	OsBootstrapEngine OperatingSystemBootstrapEngine `json:"osbootstrapengine,omitempty"`
 }
 
+// VirtualMachineCustomSize Specifies cpu/memory information for custom VMSize types.
+type VirtualMachineCustomSize struct {
+	CpuCount *int32 `json:"cpucount,omitempty"`
+	MemoryMB *int32 `json:"memorymb,omitempty"`
+}
+
 type HardwareProfile struct {
-	VMSize VirtualMachineSizeTypes `json:"vmsize,omitempty"`
+	VMSize     VirtualMachineSizeTypes   `json:"vmsize,omitempty"`
+	CustomSize *VirtualMachineCustomSize `json:"customsize,omitempty"`
 }
 
 // NetworkInterfaceReferenceProperties describes a network interface reference properties.
@@ -498,6 +505,8 @@ type VirtualMachineScaleSetStorageProfile struct {
 type VirtualMachineScaleSetHardwareProfile struct {
 	// VMSize - Specifies the size of the virtual machine.
 	VMSize VirtualMachineSizeTypes `json:"vmSize,omitempty"`
+	// CustomSize - Specifies cpu/memory information for custom VMSize types.
+	CustomSize *VirtualMachineCustomSize `json:"customsize,omitempty"`
 }
 
 // VirtualMachineScaleSetVMProfile describes a virtual machine scale set virtual machine profile.

--- a/services/compute/virtualmachine/client.go
+++ b/services/compute/virtualmachine/client.go
@@ -80,7 +80,7 @@ func (c *VirtualMachineClient) Restart(ctx context.Context, group string, name s
 }
 
 // Resize the Virtual Machine
-func (c *VirtualMachineClient) Resize(ctx context.Context, group string, name string, newSize compute.VirtualMachineSizeTypes) (err error) {
+func (c *VirtualMachineClient) Resize(ctx context.Context, group string, name string, newSize compute.VirtualMachineSizeTypes, newCustomSize *compute.VirtualMachineCustomSize) (err error) {
 	vms, err := c.Get(ctx, group, name)
 	if err != nil {
 		return
@@ -91,6 +91,7 @@ func (c *VirtualMachineClient) Resize(ctx context.Context, group string, name st
 
 	vm := (*vms)[0]
 	vm.HardwareProfile.VMSize = newSize
+	vm.HardwareProfile.CustomSize = newCustomSize
 
 	// TODO: If we get invalid Version, retry here
 	_, err = c.CreateOrUpdate(ctx, group, name, &vm)

--- a/services/compute/virtualmachine/virtualmachine.go
+++ b/services/compute/virtualmachine/virtualmachine.go
@@ -156,11 +156,19 @@ func (c *client) getWssdVirtualMachineStorageConfigurationDataDisk(s *compute.Da
 
 func (c *client) getWssdVirtualMachineHardwareConfiguration(vm *compute.VirtualMachine) (*wssdcloudcompute.HardwareConfiguration, error) {
 	sizeType := wssdcommon.VirtualMachineSizeType_Default
+	var customSize *wssdcommon.VirtualMachineCustomSize
 	if vm.HardwareProfile != nil {
 		sizeType = compute.GetCloudVirtualMachineSizeFromCloudSdkVirtualMachineSize(vm.HardwareProfile.VMSize)
+		if vm.HardwareProfile.CustomSize != nil {
+			customSize = &wssdcommon.VirtualMachineCustomSize{
+				CpuCount: *vm.HardwareProfile.CustomSize.CpuCount,
+				MemoryMB: *vm.HardwareProfile.CustomSize.MemoryMB,
+			}
+		}
 	}
 	wssdhardware := &wssdcloudcompute.HardwareConfiguration{
-		VMSize: sizeType,
+		VMSize:     sizeType,
+		CustomSize: customSize,
 	}
 	return wssdhardware, nil
 }
@@ -404,11 +412,19 @@ func (c *client) getVirtualMachineStorageProfileDataDisks(dd []*wssdcloudcompute
 
 func (c *client) getVirtualMachineHardwareProfile(vm *wssdcloudcompute.VirtualMachine) *compute.HardwareProfile {
 	sizeType := compute.VirtualMachineSizeTypesDefault
+	var customSize *compute.VirtualMachineCustomSize
 	if vm.Hardware != nil {
 		sizeType = compute.GetCloudSdkVirtualMachineSizeFromCloudVirtualMachineSize(vm.Hardware.VMSize)
+		if vm.Hardware.CustomSize != nil {
+			customSize = &compute.VirtualMachineCustomSize{
+				CpuCount: &vm.Hardware.CustomSize.CpuCount,
+				MemoryMB: &vm.Hardware.CustomSize.MemoryMB,
+			}
+		}
 	}
 	return &compute.HardwareProfile{
-		VMSize: sizeType,
+		VMSize:     sizeType,
+		CustomSize: customSize,
 	}
 }
 

--- a/services/compute/virtualmachinescaleset/virtualmachinescaleset.go
+++ b/services/compute/virtualmachinescaleset/virtualmachinescaleset.go
@@ -104,11 +104,19 @@ func (c *client) getVirtualMachineScaleSetStorageProfileDataDisk(dd *wssdcloudco
 
 func (c *client) getVirtualMachineScaleSetHardwareProfile(vm *wssdcloudcompute.VirtualMachineProfile) (*compute.VirtualMachineScaleSetHardwareProfile, error) {
 	sizeType := compute.VirtualMachineSizeTypesDefault
+	var customSize *compute.VirtualMachineCustomSize
 	if vm.Hardware != nil {
 		sizeType = compute.GetCloudSdkVirtualMachineSizeFromCloudVirtualMachineSize(vm.Hardware.VMSize)
+		if vm.Hardware.CustomSize != nil {
+			customSize = &compute.VirtualMachineCustomSize{
+				CpuCount: &vm.Hardware.CustomSize.CpuCount,
+				MemoryMB: &vm.Hardware.CustomSize.MemoryMB,
+			}
+		}
 	}
 	hardwareProfile := &compute.VirtualMachineScaleSetHardwareProfile{
-		VMSize: sizeType,
+		VMSize:     sizeType,
+		CustomSize: customSize,
 	}
 
 	return hardwareProfile, nil
@@ -385,11 +393,19 @@ func (c *client) getWssdVirtualMachineScaleSetStorageConfigurationDataDisk(d *co
 
 func (c *client) getWssdVirtualMachineScaleSetHardwareConfiguration(vmp *compute.VirtualMachineScaleSetVMProfile) (*wssdcloudcompute.HardwareConfiguration, error) {
 	sizeType := wssdcommon.VirtualMachineSizeType_Default
+	var customSize *wssdcommon.VirtualMachineCustomSize
 	if vmp.HardwareProfile != nil {
 		sizeType = compute.GetCloudVirtualMachineSizeFromCloudSdkVirtualMachineSize(vmp.HardwareProfile.VMSize)
+		if vmp.HardwareProfile.CustomSize != nil {
+			customSize = &wssdcommon.VirtualMachineCustomSize{
+				CpuCount: *vmp.HardwareProfile.CustomSize.CpuCount,
+				MemoryMB: *vmp.HardwareProfile.CustomSize.MemoryMB,
+			}
+		}
 	}
 	wssdhardware := &wssdcloudcompute.HardwareConfiguration{
-		VMSize: sizeType,
+		VMSize:     sizeType,
+		CustomSize: customSize,
 	}
 	return wssdhardware, nil
 }

--- a/services/compute/vmSizes.go
+++ b/services/compute/vmSizes.go
@@ -60,6 +60,9 @@ Standard_K8S_v1    4    2 (custom for IoT)
 Standard_K8S2_v1   2    2 (custom for IoT)
 Standard_K8S3_v1   4    6 (custom for WAC)
 Standard_K8S4_v1   4    4 (WSSD Default size)
+Standard_K8S4_v1   2    1 (custom for IoT)
+-
+Custom             *    * (custom size defined by provided mapping)
 */
 
 const (
@@ -73,6 +76,8 @@ const (
 	VirtualMachineSizeTypesStandardK8S3V1 VirtualMachineSizeTypes = "Standard_K8S3_v1"
 	// VirtualMachineSizeTypesStandardK8S4V1 ...
 	VirtualMachineSizeTypesStandardK8S4V1 VirtualMachineSizeTypes = "Standard_K8S4_v1"
+	// VirtualMachineSizeTypesStandardK8S5V1 ...
+	VirtualMachineSizeTypesStandardK8S5V1 VirtualMachineSizeTypes = "Standard_K8S5_v1"
 	// VirtualMachineSizeTypesBasicA0 ...
 	VirtualMachineSizeTypesBasicA0 VirtualMachineSizeTypes = "Basic_A0"
 	// VirtualMachineSizeTypesBasicA1 ...
@@ -413,6 +418,8 @@ const (
 	VirtualMachineSizeTypesStandardNK6 VirtualMachineSizeTypes = "Standard_NK6"
 	// VirtualMachineSizeTypesStandardNK12 ...
 	VirtualMachineSizeTypesStandardNK12 VirtualMachineSizeTypes = "Standard_NK12"
+	// VirtualMachineSizeTypesCustom ...
+	VirtualMachineSizeTypesCustom VirtualMachineSizeTypes = "Custom"
 )
 
 func GetVirtualMachineSizes() (vmsizes *[]VirtualMachineSizeTypes) {


### PR DESCRIPTION
Adding option to use a custom size for sku, allowing user to specify the memory and cpu count for vm.
Adding Standard_K8S5_v1 size for IoT with 2 cpu and 1GB ram.

This PR relies on:
https://github.com/microsoft/moc/pull/23