### PR TITLE
Run command support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.9.0
 	github.com/Azure/go-autorest/autorest/date v0.2.0
 	github.com/google/uuid v1.2.0
-	github.com/microsoft/moc v0.10.11-alpha.2
+	github.com/microsoft/moc v0.10.11-alpha.4
 	github.com/spf13/viper v1.7.1
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/grpc v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microsoft/moc v0.10.11-alpha.2 h1:9HaKu9tfcx2TkNhfqfeiMh6aCa+ZyfqiJBt+tXXvOtE=
 github.com/microsoft/moc v0.10.11-alpha.2/go.mod h1:/pDK//SuQGOcrB9Iw7V4/9D6/IPTpX/kl8663KV9raM=
+github.com/microsoft/moc v0.10.11-alpha.4 h1:lLrTBHmX0Lz6TPURhsSayQ3XcWGUQFmg+Hiuv7r60eY=
+github.com/microsoft/moc v0.10.11-alpha.4/go.mod h1:jCAZBlXWq4+uFvWV6wLUVfsZ9a/cB0hJtq3Zuii2pLA=
 github.com/miekg/dns v1.1.25/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -292,6 +294,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b h1:k+E048sYJHyVnsr1GDrRZWQ32D2C7lWs9JRc0bel53A=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
+golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -328,6 +332,8 @@ golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210611083646-a4fc73990273 h1:faDu4veV+8pcThn4fewv6TVlNCezafGoC1gM/mxQLbQ=
 golang.org/x/sys v0.0.0-20210611083646-a4fc73990273/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/services/compute/compute.go
+++ b/services/compute/compute.go
@@ -939,3 +939,60 @@ type BareMetalMachine struct {
 	// Properties
 	*BareMetalMachineProperties `json:"baremetalmachineproperties,omitempty"`
 }
+
+type ExecutionState string
+
+const (
+	// ExecutionStateFailed ...
+	ExecutionStateFailed ExecutionState = "Failed"
+	// ExecutionStateSucceeded ...
+	ExecutionStateSucceeded ExecutionState = "Succeeded"
+	// ExecutionStateUnknown ...
+	ExecutionStateUnknown ExecutionState = "Unknown"
+)
+
+// VirtualMachineRunCommandScriptSource describes the script sources for run command.
+type VirtualMachineRunCommandScriptSource struct {
+	// Script - Specifies the script content to be executed on the VM.
+	Script *string `json:"script,omitempty"`
+	// ScriptURI - Specifies the script download location.
+	ScriptURI *string `json:"scriptUri,omitempty"`
+	// CommandID - Specifies a commandId of predefined built-in script.
+	CommandID *string `json:"commandId,omitempty"`
+}
+
+// RunCommandInputParameter describes the properties of a run command parameter.
+type RunCommandInputParameter struct {
+	// Name - The run command parameter name.
+	Name *string `json:"name,omitempty"`
+	// Value - The run command parameter value.
+	Value *string `json:"value,omitempty"`
+}
+
+// VirtualMachineRunCommandInstanceView the instance view of a virtual machine run command.
+type VirtualMachineRunCommandInstanceView struct {
+	// ExecutionState - Script execution status. Possible values include: 'ExecutionStateUnknown', 'ExecutionStateFailed', 'ExecutionStateSucceeded'
+	ExecutionState ExecutionState `json:"executionState,omitempty"`
+	// ExitCode - Exit code returned from script execution.
+	ExitCode *int32 `json:"exitCode,omitempty"`
+	// Output - Script output stream.
+	Output *string `json:"output,omitempty"`
+	// Error - Script error stream.
+	Error *string `json:"error,omitempty"`
+}
+
+// VirtualMachineRunCommandRequest describes the properties of a Virtual Machine run command.
+type VirtualMachineRunCommandRequest struct {
+	// Source - The source of the run command script.
+	Source *VirtualMachineRunCommandScriptSource `json:"source,omitempty"`
+	// Parameters - The parameters used by the script.
+	Parameters    *[]RunCommandInputParameter `json:"parameters,omitempty"`
+	RunAsUser     *string                     `json:"runasuser,omitempty"`
+	RunAsPassword *string                     `json:"runaspassword,omitempty"`
+}
+
+// VirtualMachineRunCommandResponse
+type VirtualMachineRunCommandResponse struct {
+	// InstanceView - The virtual machine run command instance view.
+	InstanceView *VirtualMachineRunCommandInstanceView `json:"instanceView,omitempty"`
+}

--- a/services/compute/virtualmachine/client.go
+++ b/services/compute/virtualmachine/client.go
@@ -21,6 +21,7 @@ type Service interface {
 	Query(context.Context, string, string) (*[]compute.VirtualMachine, error)
 	Start(context.Context, string, string) error
 	Stop(context.Context, string, string) error
+	RunCommand(context.Context, string, string, *compute.VirtualMachineRunCommandRequest) (*compute.VirtualMachineRunCommandResponse, error)
 }
 
 type VirtualMachineClient struct {
@@ -291,4 +292,8 @@ func (c *VirtualMachineClient) GetByComputerName(ctx context.Context, group stri
 	}
 
 	return vms, nil
+}
+
+func (c *VirtualMachineClient) RunCommand(ctx context.Context, group, vmName string, request *compute.VirtualMachineRunCommandRequest) (response *compute.VirtualMachineRunCommandResponse, err error) {
+	return c.internal.RunCommand(ctx, group, vmName, request)
 }

--- a/services/compute/virtualmachine/wssd.go
+++ b/services/compute/virtualmachine/wssd.go
@@ -206,12 +206,12 @@ func (c *client) getVirtualMachineRunCommandRequest(ctx context.Context, group, 
 func (c *client) getVirtualMachineRunCommandResponse(mocResponse *wssdcloudcompute.VirtualMachineRunCommandResponse) (*compute.VirtualMachineRunCommandResponse, error) {
 	var executionState compute.ExecutionState
 	switch mocResponse.GetInstanceView().ExecutionState {
-	case 0:
-		executionState = compute.ExecutionStateFailed
-	case 1:
-		executionState = compute.ExecutionStateSucceeded
-	case 2:
+	case wssdcloudproto.VirtualMachineRunCommandExecutionState_ExecutionState_UNKNOWN:
 		executionState = compute.ExecutionStateUnknown
+	case wssdcloudproto.VirtualMachineRunCommandExecutionState_ExecutionState_SUCCEEDED:
+		executionState = compute.ExecutionStateSucceeded
+	case wssdcloudproto.VirtualMachineRunCommandExecutionState_ExecutionState_FAILED:
+		executionState = compute.ExecutionStateFailed
 	default:
 		return nil, errors.Wrapf(errors.NotSupported, "Unknown execution state reported for virtual machine run command")
 	}

--- a/services/compute/virtualmachine/wssd.go
+++ b/services/compute/virtualmachine/wssd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/microsoft/moc-sdk-for-go/services/compute"
 	"github.com/microsoft/moc/pkg/auth"
 	"github.com/microsoft/moc/pkg/config"
+	"github.com/microsoft/moc/pkg/errors"
 	"github.com/microsoft/moc/pkg/marshal"
 	prototags "github.com/microsoft/moc/pkg/tags"
 	wssdcloudproto "github.com/microsoft/moc/rpc/common"
@@ -136,7 +137,98 @@ func (c *client) Start(ctx context.Context, group, name string) (err error) {
 	return
 }
 
+// RunCommand
+func (c *client) RunCommand(ctx context.Context, group, name string, request *compute.VirtualMachineRunCommandRequest) (response *compute.VirtualMachineRunCommandResponse, err error) {
+	mocRequest, err := c.getVirtualMachineRunCommandRequest(ctx, group, name, request)
+	if err != nil {
+		return
+	}
+
+	mocResponse, err := c.VirtualMachineAgentClient.RunCommand(ctx, mocRequest)
+	if err != nil {
+		return
+	}
+	response, err = c.getVirtualMachineRunCommandResponse(mocResponse)
+	return
+}
+
 // Private methods
+func (c *client) getVirtualMachineRunCommandRequest(ctx context.Context, group, name string, request *compute.VirtualMachineRunCommandRequest) (mocRequest *wssdcloudcompute.VirtualMachineRunCommandRequest, err error) {
+	vms, err := c.get(ctx, group, name)
+	if err != nil {
+		return
+	}
+
+	if len(vms) != 1 {
+		err = errors.Wrapf(errors.InvalidInput, "Multiple Virtual Machines found in group %s with name %s", group, name)
+		return
+	}
+	vm := vms[0]
+
+	var params []*wssdcloudproto.VirtualMachineRunCommandInputParameter
+	if request.Parameters != nil {
+		params = make([]*wssdcloudproto.VirtualMachineRunCommandInputParameter, len(*request.Parameters))
+		for i, param := range *request.Parameters {
+			tmp := &wssdcloudproto.VirtualMachineRunCommandInputParameter{
+				Name:  *param.Name,
+				Value: *param.Value,
+			}
+			params[i] = tmp
+		}
+	}
+
+	var scriptSource wssdcloudproto.VirtualMachineRunCommandScriptSource
+	if request.Source.Script != nil {
+		scriptSource.Script = *request.Source.Script
+	}
+	if request.Source.ScriptURI != nil {
+		scriptSource.ScriptURI = *request.Source.ScriptURI
+	}
+	if request.Source.CommandID != nil {
+		scriptSource.CommandID = *request.Source.CommandID
+	}
+
+	mocRequest = &wssdcloudcompute.VirtualMachineRunCommandRequest{
+		VirtualMachine:            vm,
+		RunCommandInputParameters: params,
+		Source:                    &scriptSource,
+	}
+
+	if request.RunAsUser != nil {
+		mocRequest.RunAsUser = *request.RunAsUser
+	}
+	if request.RunAsPassword != nil {
+		mocRequest.RunAsPassword = *request.RunAsPassword
+	}
+	return
+}
+
+func (c *client) getVirtualMachineRunCommandResponse(mocResponse *wssdcloudcompute.VirtualMachineRunCommandResponse) (*compute.VirtualMachineRunCommandResponse, error) {
+	var executionState compute.ExecutionState
+	switch mocResponse.GetInstanceView().ExecutionState {
+	case 0:
+		executionState = compute.ExecutionStateFailed
+	case 1:
+		executionState = compute.ExecutionStateSucceeded
+	case 2:
+		executionState = compute.ExecutionStateUnknown
+	default:
+		return nil, errors.Wrapf(errors.NotSupported, "Unknown execution state reported for virtual machine run command")
+	}
+
+	instanceView := &compute.VirtualMachineRunCommandInstanceView{
+		ExecutionState: executionState,
+		ExitCode:       &mocResponse.GetInstanceView().ExitCode,
+		Output:         &mocResponse.GetInstanceView().Output,
+		Error:          &mocResponse.GetInstanceView().Error,
+	}
+
+	response := &compute.VirtualMachineRunCommandResponse{
+		InstanceView: instanceView,
+	}
+	return response, nil
+}
+
 func (c *client) getVirtualMachineFromResponse(response *wssdcloudcompute.VirtualMachineResponse, group string) *[]compute.VirtualMachine {
 	vms := []compute.VirtualMachine{}
 	for _, vm := range response.GetVirtualMachines() {


### PR DESCRIPTION
## Changes introduced by this PR
- Upgrade to new moc version
- Add RunCommand structs
- Add RunCommand function to VirtualMachineClient
- Add sdk to moc VirtualMachineRunCommandRequest conversion function
- Add moc to sdk VirtualMachineRunCommandResponse conversion function

## Test Plan
- Added cloud and node yaml tests to call RunCommand and expect NotSupported error (stub in nodeagent)
- Further tests will be onboarded as VM Day 0 operations to support remote execution are implemented