### PR TITLE
Change GetVirtualMachineSizeValues to return slice pointer

### DIFF
--- a/services/compute/vmSizes.go
+++ b/services/compute/vmSizes.go
@@ -452,7 +452,7 @@ func GetVirtualMachineSizes() (vmsizes *[]VirtualMachineSizeTypes) {
 	return
 }
 
-func GetVirtualMachineSizeValues(vmsizes *[]VirtualMachineSizes) {
+func GetVirtualMachineSizeValues() (vmsizes *[]VirtualMachineSizes) {
 	tmp := []VirtualMachineSizes{}
 
 	for k, v := range wcommon.VirtualMachineSize_value {


### PR DESCRIPTION
## Changes introduced by this PR

- Update GetVirtualMachineSizeValues to return a pointer to the slice of VM sizes that the function constructs
- I think for the current implementation, a double pointer rather than a single pointer would be required as input, but it is a bit simpler to just return the list in my opinion