### PR TITLE
add keyRotationFrequencyInSeconds to Key properties

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,9 @@ require (
 	github.com/Azure/go-autorest/autorest v0.9.0
 	github.com/Azure/go-autorest/autorest/date v0.2.0
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/uuid v1.2.0
-	github.com/microsoft/moc v0.10.16-alpha.2
+	github.com/microsoft/moc v0.10.19-alpha.1
 	github.com/spf13/viper v1.7.1
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/grpc v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microsoft/moc v0.10.16-alpha.2 h1:CbJMhkxym3pvqN/9h0iZbkZqX6WMTquASeo4oaXW3/0=
 github.com/microsoft/moc v0.10.16-alpha.2/go.mod h1:biJWGYHYLUkgeP/MfvG5omQHQgAi1uFBKIceE4xSg54=
+github.com/microsoft/moc v0.10.19-alpha.1 h1:5JlRcz1osw+SK7jq41dGiw/nKeKF1G3/2JyaG3PF1dQ=
+github.com/microsoft/moc v0.10.19-alpha.1/go.mod h1:jIiMCje0mhU1iQF8KJqdKwUfEf3yKrxzfG1oDm7+pYw=
 github.com/miekg/dns v1.1.25/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -292,6 +294,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20211020060615-d418f374d309 h1:A0lJIi+hcTR6aajJH4YqKWwohY4aW9RO7oRMcdv+HKI=
 golang.org/x/net v0.0.0-20211020060615-d418f374d309/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -326,9 +330,14 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359 h1:2B5p2L5IfGiD7+b9BOoRMC6DgObAVZV+Fsp050NqXik=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220207234003-57398862261d h1:Bm7BNOQt2Qv7ZqysjeLjgCBanX+88Z/OtdvsrEv1Djc=
+golang.org/x/sys v0.0.0-20220207234003-57398862261d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -403,6 +412,8 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/services/security/keyvault/key/key.go
+++ b/services/security/keyvault/key/key.go
@@ -37,9 +37,10 @@ func getKey(sec *wssdcloudsecurity.Key, vaultName string) (keyvault.Key, error) 
 		Version: &sec.Status.Version.Number,
 		Value:   &value,
 		KeyProperties: &keyvault.KeyProperties{
-			Statuses: status.GetStatuses(sec.GetStatus()),
-			KeyType:  getKeyType(sec.Type),
-			KeySize:  keysize,
+			Statuses:                      status.GetStatuses(sec.GetStatus()),
+			KeyType:                       getKeyType(sec.Type),
+			KeySize:                       keysize,
+			KeyRotationFrequencyInSeconds: &sec.KeyRotationFrequencyInSeconds,
 		},
 	}, nil
 }
@@ -67,13 +68,14 @@ func getWssdKey(name string, sec *keyvault.Key,
 		return nil, err
 	}
 	key := &wssdcloudsecurity.Key{
-		Name:      name,
-		VaultName: vaultName,
-		GroupName: groupName,
-		Type:      getMOCKeyType(sec.KeyType),
-		Size:      keysize,
-		KeyOps:    []wssdcloudcommon.KeyOperation{},
-		Status:    status.InitStatus(),
+		Name:                          name,
+		VaultName:                     vaultName,
+		GroupName:                     groupName,
+		Type:                          getMOCKeyType(sec.KeyType),
+		Size:                          keysize,
+		KeyOps:                        []wssdcloudcommon.KeyOperation{},
+		Status:                        status.InitStatus(),
+		KeyRotationFrequencyInSeconds: *sec.KeyRotationFrequencyInSeconds,
 	}
 
 	// No Update support

--- a/services/security/keyvault/key/key.go
+++ b/services/security/keyvault/key/key.go
@@ -67,6 +67,13 @@ func getWssdKey(name string, sec *keyvault.Key,
 	if err != nil {
 		return nil, err
 	}
+
+	var keyRotationValue int64
+	keyRotationValue = 0
+	if sec.KeyRotationFrequencyInSeconds != nil {
+		keyRotationValue = *sec.KeyRotationFrequencyInSeconds
+	}
+
 	key := &wssdcloudsecurity.Key{
 		Name:                          name,
 		VaultName:                     vaultName,
@@ -75,7 +82,7 @@ func getWssdKey(name string, sec *keyvault.Key,
 		Size:                          keysize,
 		KeyOps:                        []wssdcloudcommon.KeyOperation{},
 		Status:                        status.InitStatus(),
-		KeyRotationFrequencyInSeconds: *sec.KeyRotationFrequencyInSeconds,
+		KeyRotationFrequencyInSeconds: keyRotationValue,
 	}
 
 	// No Update support

--- a/services/security/keyvault/keyvault.go
+++ b/services/security/keyvault/keyvault.go
@@ -90,6 +90,8 @@ type KeyProperties struct {
 	Curve JSONWebKeyCurveName `json:"crv,omitempty"`
 	// State - State
 	Statuses map[string]*string `json:"statuses"`
+	// KeyRotationFrequencyInSeconds - Configures key rotation frequency.
+	KeyRotationFrequencyInSeconds *int64 `json:"keyRotationFrequencyInSeconds,omitempty"`
 }
 
 // KeyOperationResult the key operation result.


### PR DESCRIPTION
This PR added a new field to allow configuration key rotation frequency.

Design doc: https://github.com/microsoft/wssdagent/pull/618

Testing:
New test cases added to WssdTesting and being tested locally that covers:
1. If key rotation frequency is set to -1, then the AES key does not rotate
2. If key rotation frequency is set to positive value, then the AES key rotates

OS tracking task for ASZ: [Task 37702743](https://microsoft.visualstudio.com/OS/_workitems/edit/37702743): ASZ R1: Implement the option to not do key rotation