### PR TITLE
publish generated Moc SDK cpp dll in pipeline

### DIFF
--- a/.pipelines/build.yaml
+++ b/.pipelines/build.yaml
@@ -41,5 +41,7 @@ jobs:
     inputs:
       BuildDropPath: $(System.DefaultWorkingDirectory)/manifest
 
+  - publish: $(System.DefaultWorkingDirectory)/bin
+    artifact: binaries
   - publish: $(System.DefaultWorkingDirectory)/manifest
     artifact: manifest


### PR DESCRIPTION
This is a follow up PR for https://github.com/microsoft/moc-sdk-for-go/pull/101

Right now the generated cpp wrapper is not published via moc sdk pipeline. Adding it to the pipeline so that other repo can consume the dll.