### PR TITLE
Update cpp Encrypt/Decrypt return string

### DIFF
--- a/wrapper/cpp/main.go
+++ b/wrapper/cpp/main.go
@@ -21,8 +21,9 @@ import (
 //export KeyvaultKeyEncryptData
 func KeyvaultKeyEncryptData(serverName *C.char, groupName *C.char, keyvaultName *C.char, keyName *C.char, input *C.char, timeoutInSeconds C.int) *C.char {
     keyClient, err := getKeyvaultKeyClient(C.GoString(serverName))
+    // if errror occurs, return an empty string so that caller can tell between error and encrypted blob
     if err != nil {
-        return C.CString(err.Error())
+        return C.CString("")
     }
 
     ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutInSeconds)*time.Second)
@@ -39,7 +40,7 @@ func KeyvaultKeyEncryptData(serverName *C.char, groupName *C.char, keyvaultName 
 
     response, err := keyClient.Encrypt(ctx, C.GoString(groupName), C.GoString(keyvaultName), C.GoString(keyName), parameters)
     if err != nil {
-        return C.CString(err.Error())
+        return C.CString("")
     }
 
     // retrun base64 encoded string
@@ -49,8 +50,9 @@ func KeyvaultKeyEncryptData(serverName *C.char, groupName *C.char, keyvaultName 
 //export KeyvaultKeyDecryptData
 func KeyvaultKeyDecryptData(serverName *C.char, groupName *C.char, keyvaultName *C.char, keyName *C.char, input *C.char, timeoutInSeconds C.int) *C.char {
     keyClient, err := getKeyvaultKeyClient(C.GoString(serverName))
+    // if errror occurs, return an empty string so that caller can tell between error and decrypted blob
     if err != nil {
-        return C.CString(err.Error())
+        return C.CString("")
     }
 
     ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutInSeconds)*time.Second)
@@ -66,7 +68,7 @@ func KeyvaultKeyDecryptData(serverName *C.char, groupName *C.char, keyvaultName 
 
     response, err := keyClient.Decrypt(ctx, C.GoString(groupName), C.GoString(keyvaultName), C.GoString(keyName), parameters)
     if err != nil {
-        return C.CString(err.Error())
+        return C.CString("")
     }
 
     return  C.CString(*response.Result)


### PR DESCRIPTION
Currently KeyvaultKeyDecryptData() and KeyvaultKeyEncryptData() will return a string that contains either error message (on failure case) and encrypted/decrypted blob (on success case). It is hard for caller to tell whether this call succeeded or not.

In the PR, the return string is changed to empty in failure case.