### PR TITLE
Updating SDK to support key import/export APIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.2.0
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/google/uuid v1.2.0
-	github.com/microsoft/moc v0.10.20-alpha.1
+	github.com/microsoft/moc v0.10.21-alpha.1
 	github.com/spf13/viper v1.7.1
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/grpc v1.27.1

--- a/go.sum
+++ b/go.sum
@@ -158,12 +158,8 @@ github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/microsoft/moc v0.10.19-alpha.10 h1:pY5La4HS+ESku3UX9qDWzvtm9PW+yFtfNlFWzRDfX/w=
-github.com/microsoft/moc v0.10.19-alpha.10/go.mod h1:aYLN9HiWq82+lnPzPixbBhEq/gfgx1KLmpiwlnqhQ58=
-github.com/microsoft/moc v0.10.20-alpha.1 h1:a+VLZrOdWYpfX04G1VDTqMFpvuKHX5jjxTiFv5waP2E=
-github.com/microsoft/moc v0.10.20-alpha.1/go.mod h1:aYLN9HiWq82+lnPzPixbBhEq/gfgx1KLmpiwlnqhQ58=
-github.com/microsoft/moc v0.10.21-0.20220430002743-1cc9809a7950 h1:5YWarfZJu6KwHVg/64hMLEkKYrGTXzGe15JpqU/XAV0=
-github.com/microsoft/moc v0.10.21-0.20220430002743-1cc9809a7950/go.mod h1:aYLN9HiWq82+lnPzPixbBhEq/gfgx1KLmpiwlnqhQ58=
+github.com/microsoft/moc v0.10.21-alpha.1 h1:Z9ZmoJYHiRHfT+uniHdXOv8CPhAcPNtSnn/mDlhPsNg=
+github.com/microsoft/moc v0.10.21-alpha.1/go.mod h1:aYLN9HiWq82+lnPzPixbBhEq/gfgx1KLmpiwlnqhQ58=
 github.com/miekg/dns v1.1.25/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/services/security/keyvault/key/client.go
+++ b/services/security/keyvault/key/client.go
@@ -5,6 +5,7 @@ package key
 
 import (
 	"context"
+
 	"github.com/microsoft/moc-sdk-for-go/services/security"
 	"github.com/microsoft/moc-sdk-for-go/services/security/keyvault"
 	"github.com/microsoft/moc/pkg/auth"
@@ -19,6 +20,7 @@ type Service interface {
 	Decrypt(context.Context, string, string, string, *keyvault.KeyOperationsParameters) (*keyvault.KeyOperationResult, error)
 	WrapKey(context.Context, string, string, string, *keyvault.KeyOperationsParameters) (*keyvault.KeyOperationResult, error)
 	UnwrapKey(context.Context, string, string, string, *keyvault.KeyOperationsParameters) (*keyvault.KeyOperationResult, error)
+	ImportKey(context.Context, string, string, string, *keyvault.Key) (*keyvault.Key, error)
 }
 
 // Client structure

--- a/services/security/keyvault/key/client.go
+++ b/services/security/keyvault/key/client.go
@@ -21,6 +21,7 @@ type Service interface {
 	WrapKey(context.Context, string, string, string, *keyvault.KeyOperationsParameters) (*keyvault.KeyOperationResult, error)
 	UnwrapKey(context.Context, string, string, string, *keyvault.KeyOperationsParameters) (*keyvault.KeyOperationResult, error)
 	ImportKey(context.Context, string, string, string, *keyvault.Key) (*keyvault.Key, error)
+	ExportKey(context.Context, string, string, string, *keyvault.Key) (*keyvault.Key, error)
 }
 
 // Client structure
@@ -48,6 +49,18 @@ func (c *KeyClient) Get(ctx context.Context, group, vaultName, name string) (*[]
 func (c *KeyClient) CreateOrUpdate(ctx context.Context, group, vaultName, name string,
 	param *keyvault.Key) (*keyvault.Key, error) {
 	return c.internal.CreateOrUpdate(ctx, group, vaultName, name, param)
+}
+
+// Import methods invokes import on the client
+func (c *KeyClient) Import(ctx context.Context, group, vaultName, name string,
+	param *keyvault.Key) (*keyvault.Key, error) {
+	return c.internal.ImportKey(ctx, group, vaultName, name, param)
+}
+
+// Export methods invokes export on the client
+func (c *KeyClient) Export(ctx context.Context, group, vaultName, name string,
+	param *keyvault.Key) (*keyvault.Key, error) {
+	return c.internal.ExportKey(ctx, group, vaultName, name, param)
 }
 
 // Delete methods invokes delete of the keyvault resource

--- a/services/security/keyvault/key/key.go
+++ b/services/security/keyvault/key/key.go
@@ -261,7 +261,7 @@ func GetMOCKeyWrappingAlgorithm(algo keyvault.KeyWrappingAlgorithm) (wrappingAlg
 	case keyvault.CKM_RSA_AES_KEY_WRAP:
 		wrappingAlgo = wssdcloudcommon.KeyWrappingAlgorithm_CKM_RSA_AES_KEY_WRAP
 	case keyvault.None:
-		wrappingAlgo = wssdcloudcommon.KeyWrappingAlgorithm_None
+		wrappingAlgo = wssdcloudcommon.KeyWrappingAlgorithm_NO_KEY_WRAP
 	default:
 		err = errors.Wrapf(errors.InvalidInput, "Invalid Algorithm [%s]", algo)
 	}

--- a/services/security/keyvault/key/key.go
+++ b/services/security/keyvault/key/key.go
@@ -271,8 +271,6 @@ func GetMOCKeyWrappingAlgorithm(algo keyvault.KeyWrappingAlgorithm) (wrappingAlg
 	switch algo {
 	case keyvault.CKM_RSA_AES_KEY_WRAP:
 		wrappingAlgo = wssdcloudcommon.KeyWrappingAlgorithm_CKM_RSA_AES_KEY_WRAP
-	case keyvault.NO_KEY_WRAP:
-		wrappingAlgo = wssdcloudcommon.KeyWrappingAlgorithm_NO_KEY_WRAP
 	default:
 		err = errors.Wrapf(errors.InvalidInput, "Invalid Algorithm [%s]", algo)
 	}
@@ -283,8 +281,6 @@ func GetKeyWrappingAlgorithm(algo wssdcloudcommon.KeyWrappingAlgorithm) (wrappin
 	switch algo {
 	case wssdcloudcommon.KeyWrappingAlgorithm_CKM_RSA_AES_KEY_WRAP:
 		wrappingAlgo = keyvault.CKM_RSA_AES_KEY_WRAP
-	case wssdcloudcommon.KeyWrappingAlgorithm_NO_KEY_WRAP:
-		wrappingAlgo = keyvault.NO_KEY_WRAP
 	default:
 		err = errors.Wrapf(errors.Failed, "Invalid Algorithm [%s]", algo)
 	}

--- a/services/security/keyvault/key/key.go
+++ b/services/security/keyvault/key/key.go
@@ -260,7 +260,7 @@ func GetMOCKeyWrappingAlgorithm(algo keyvault.KeyWrappingAlgorithm) (wrappingAlg
 	switch algo {
 	case keyvault.CKM_RSA_AES_KEY_WRAP:
 		wrappingAlgo = wssdcloudcommon.KeyWrappingAlgorithm_CKM_RSA_AES_KEY_WRAP
-	case keyvault.None:
+	case keyvault.NO_KEY_WRAP:
 		wrappingAlgo = wssdcloudcommon.KeyWrappingAlgorithm_NO_KEY_WRAP
 	default:
 		err = errors.Wrapf(errors.InvalidInput, "Invalid Algorithm [%s]", algo)

--- a/services/security/keyvault/key/key.go
+++ b/services/security/keyvault/key/key.go
@@ -5,6 +5,7 @@ package key
 
 import (
 	"encoding/pem"
+
 	"github.com/microsoft/moc-sdk-for-go/services/security/keyvault"
 
 	"github.com/microsoft/moc/pkg/convert"
@@ -253,4 +254,16 @@ func GetMOCAlgorithmType(algo string) (keyvault.JSONWebKeyEncryptionAlgorithm, e
 		return keyvault.A256KW, nil
 	}
 	return keyvault.RSA15, errors.Wrapf(errors.InvalidInput, "Invalid Algorithm [%s]", algo)
+}
+
+func GetMOCKeyWrappingAlgorithm(algo keyvault.KeyWrappingAlgorithm) (wrappingAlgo wssdcloudcommon.KeyWrappingAlgorithm, err error) {
+	switch algo {
+	case keyvault.CKM_RSA_AES_KEY_WRAP:
+		wrappingAlgo = wssdcloudcommon.KeyWrappingAlgorithm_CKM_RSA_AES_KEY_WRAP
+	case keyvault.None:
+		wrappingAlgo = wssdcloudcommon.KeyWrappingAlgorithm_None
+	default:
+		err = errors.Wrapf(errors.InvalidInput, "Invalid Algorithm [%s]", algo)
+	}
+	return
 }

--- a/services/security/keyvault/key/wssd.go
+++ b/services/security/keyvault/key/wssd.go
@@ -121,17 +121,11 @@ func ParseAndValidateExportParams(keyValue *string, exportKey *wssdcloudsecurity
 		return err
 	}
 
-	// Validate for Export
-	var wrappingKeyPublic []byte
-	if keyWrappingAlgo == wssdcloudcommon.KeyWrappingAlgorithm_NO_KEY_WRAP {
-		// Key wrapping algorithm 'NO_KEY_WRAP' not allowed for Export operation
-		return errors.Wrapf(errors.NotSupported, "Unsupported key wrapping algorithm")
-	}
 	if parsedExportParams.PrivateKeyWrappingInfo.PublicKey == nil {
 		// Wrapping public key mandatory for Export
 		return errors.Wrapf(errors.InvalidInput, "Wrapping public key - Missing")
 	}
-	wrappingKeyPublic, err = base64.URLEncoding.DecodeString(*parsedExportParams.PrivateKeyWrappingInfo.PublicKey)
+	wrappingKeyPublic, err := base64.URLEncoding.DecodeString(*parsedExportParams.PrivateKeyWrappingInfo.PublicKey)
 	if err != nil {
 		return err
 	}
@@ -154,7 +148,6 @@ func ParseAndValidateImportParams(keyValue *string, importKey *wssdcloudsecurity
 		return err
 	}
 
-	// Validate for Import
 	if parsedImportParams.PublicKey == nil {
 		return errors.Wrapf(errors.InvalidInput, "Public key - Missing")
 	}
@@ -171,14 +164,10 @@ func ParseAndValidateImportParams(keyValue *string, importKey *wssdcloudsecurity
 		return err
 	}
 
-	var wrappingKeyName string
-	if keyWrappingAlgo != wssdcloudcommon.KeyWrappingAlgorithm_NO_KEY_WRAP {
-		if parsedImportParams.PrivateKeyWrappingInfo.KeyName == nil {
-			// Wrapping key name mandatory for Import if wrapping algorithm is not 'none'
-			return errors.Wrapf(errors.InvalidInput, "Wrapping key name - Missing")
-		}
-		wrappingKeyName = *parsedImportParams.PrivateKeyWrappingInfo.KeyName
+	if parsedImportParams.PrivateKeyWrappingInfo.KeyName == nil {
+		return errors.Wrapf(errors.InvalidInput, "Wrapping key name - Missing")
 	}
+	wrappingKeyName := *parsedImportParams.PrivateKeyWrappingInfo.KeyName
 
 	importKey.PrivateKeyWrappingInfo = &wssdcloudsecurity.PrivateKeyWrappingInfo{
 		WrappingKeyName:   wrappingKeyName,

--- a/services/security/keyvault/key/wssd.go
+++ b/services/security/keyvault/key/wssd.go
@@ -124,7 +124,7 @@ func ParseAndValidateExportParams(keyValue *string, exportKey *wssdcloudsecurity
 	// Validate for Export
 	var wrappingKeyPublic []byte
 	if keyWrappingAlgo == wssdcloudcommon.KeyWrappingAlgorithm_NO_KEY_WRAP {
-		// Key wrapping algorithm 'none' not allowed for Export operation
+		// Key wrapping algorithm 'NO_KEY_WRAP' not allowed for Export operation
 		return errors.Wrapf(errors.NotSupported, "Unsupported key wrapping algorithm")
 	}
 	if parsedExportParams.PrivateKeyWrappingInfo.PublicKey == nil {

--- a/services/security/keyvault/key/wssd.go
+++ b/services/security/keyvault/key/wssd.go
@@ -123,7 +123,7 @@ func ParseAndValidateExportParams(keyValue *string, exportKey *wssdcloudsecurity
 
 	// Validate for Export
 	var wrappingKeyPublic []byte
-	if keyWrappingAlgo == wssdcloudcommon.KeyWrappingAlgorithm_None {
+	if keyWrappingAlgo == wssdcloudcommon.KeyWrappingAlgorithm_NO_KEY_WRAP {
 		// Key wrapping algorithm 'none' not allowed for Export operation
 		return errors.Wrapf(errors.NotSupported, "Unsupported key wrapping algorithm")
 	}
@@ -167,7 +167,7 @@ func ParseAndValidateImportParams(keyValue *string, importKey *wssdcloudsecurity
 	}
 
 	var wrappingKeyName string
-	if keyWrappingAlgo != wssdcloudcommon.KeyWrappingAlgorithm_None {
+	if keyWrappingAlgo != wssdcloudcommon.KeyWrappingAlgorithm_NO_KEY_WRAP {
 		if parsedImportParams.PrivateKeyWrappingInfo.KeyName == nil {
 			// Wrapping key name mandatory for Import if wrapping algorithm is not 'none'
 			return errors.Wrapf(errors.InvalidInput, "Wrapping key name - Missing")

--- a/services/security/keyvault/keyvault.go
+++ b/services/security/keyvault/keyvault.go
@@ -4,6 +4,8 @@
 package keyvault
 
 import (
+	"encoding/json"
+
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/date"
 
@@ -267,4 +269,18 @@ func getWssdKeyVault(vault *security.KeyVault, group string) (*wssdcloudsecurity
 	}
 
 	return keyvault, nil
+}
+
+func GetKeyImportExportJsonValue(publicKey, privateKey, wrappingKeyName, wrappingPubKey *string, keyWrappingAlgo *KeyWrappingAlgorithm) (string, error) {
+	keyImportExportValue := KeyImportExportValue{
+		PublicKey:  publicKey,
+		PrivateKey: privateKey,
+		PrivateKeyWrappingInfo: &PrivateKeyWrappingInfo{
+			KeyName:              wrappingKeyName,
+			PublicKey:            wrappingPubKey,
+			KeyWrappingAlgorithm: keyWrappingAlgo,
+		},
+	}
+	jsonBytes, err := json.Marshal(keyImportExportValue)
+	return string(jsonBytes), err
 }

--- a/services/security/keyvault/keyvault.go
+++ b/services/security/keyvault/keyvault.go
@@ -200,6 +200,39 @@ type Key struct {
 	*KeyProperties `json:"properties,omitempty"`
 }
 
+// KeyWrappingAlgorithm enumerates the values for private key wrapping info for key import export operations.
+type KeyWrappingAlgorithm string
+
+const (
+	// CKM_RSA_AES_KEY_WRAP
+	CKM_RSA_AES_KEY_WRAP KeyWrappingAlgorithm = "CKM_RSA_AES_KEY_WRAP"
+	// None
+	None KeyWrappingAlgorithm = "none"
+)
+
+// Defines private key wrapping infor for key import/export operations
+type PrivateKeyWrappingInfo struct {
+	// KeyName - READ-ONLY; Name of the wrapping key
+	KeyName *string `json:"key-name,omitempty"`
+	// PublicKey - Public key of the wrapping key
+	PublicKey *string `json:"public-key,omitempty"`
+	// KeyWrappingAlgorithm - Key wrapping algorithm
+	KeyWrappingAlgorithm *KeyWrappingAlgorithm `json:"enc,omitempty"`
+}
+
+// Defines the parameters for key import/export operations.
+// Key import/export operations expect Json string equivalent of this struct in Key.Value field
+type KeyImportExportValue struct {
+	// Version - READ-ONLY; Version of the KeyImportExportValue JSON.
+	Version *string `json:"version,omitempty"`
+	// PublicKey
+	PublicKey *string `json:"public-key,omitempty"`
+	// PrivateKey
+	PrivateKey *string `json:"private-key,omitempty"`
+	// PrivateKeyWrappingInfo
+	PrivateKeyWrappingInfo *PrivateKeyWrappingInfo `json:"private-key-wrapping-info,omitempty"`
+}
+
 func getKeyVault(vault *wssdcloudsecurity.KeyVault, group string) *security.KeyVault {
 	return &security.KeyVault{
 		ID:      &vault.Id,

--- a/services/security/keyvault/keyvault.go
+++ b/services/security/keyvault/keyvault.go
@@ -206,8 +206,8 @@ type KeyWrappingAlgorithm string
 const (
 	// CKM_RSA_AES_KEY_WRAP
 	CKM_RSA_AES_KEY_WRAP KeyWrappingAlgorithm = "CKM_RSA_AES_KEY_WRAP"
-	// None
-	None KeyWrappingAlgorithm = "none"
+	// NO_KEY_WRAP
+	NO_KEY_WRAP KeyWrappingAlgorithm = "NO_KEY_WRAP"
 )
 
 // Defines private key wrapping infor for key import/export operations
@@ -224,7 +224,7 @@ type PrivateKeyWrappingInfo struct {
 // Key import/export operations expect Json string equivalent of this struct in Key.Value field
 type KeyImportExportValue struct {
 	// Version - READ-ONLY; Version of the KeyImportExportValue JSON.
-	Version *string `json:"version,omitempty"`
+	Version string `json:"version,omitempty"`
 	// PublicKey
 	PublicKey *string `json:"public-key,omitempty"`
 	// PrivateKey


### PR DESCRIPTION
We need to implement these APIs to enable disaster recovery and inter-cluster VM migration. Design documentation can be found at: https://github.com/microsoft/wssdagent/blob/user/nishinde/keyimportexport/doc/cloudagent-key-import-export.md