### PR TITLE
Absolute File path check for identity

### DIFF
--- a/services/security/identity/identity.go
+++ b/services/security/identity/identity.go
@@ -4,6 +4,8 @@
 package identity
 
 import (
+	"path/filepath"
+
 	"github.com/microsoft/moc-sdk-for-go/services/security"
 
 	"github.com/microsoft/moc/pkg/auth"
@@ -56,6 +58,9 @@ func getWssdIdentity(id *security.Identity) (*wssdcloudsecurity.Identity, error)
 		return nil, errors.Wrapf(errors.InvalidInput, "Identity name is missing")
 	}
 
+	if !(filepath.IsAbs(*id.LoginFilePath)) {
+		return nil, errors.Wrapf(errors.InvalidInput, "Identity Loginfile must be absolute filepath")
+	}
 	wssdidentity := &wssdcloudsecurity.Identity{
 		Name: *id.Name,
 	}


### PR DESCRIPTION
The login-file provided for identity must be absolute file path and not relatively, otherwise the login file will not get written and the token will not be rotated.