### PR TITLE
Update LoginFilepath checks

### DIFF
--- a/services/security/identity/identity.go
+++ b/services/security/identity/identity.go
@@ -4,6 +4,7 @@
 package identity
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/microsoft/moc-sdk-for-go/services/security"
@@ -59,6 +60,7 @@ func getWssdIdentity(id *security.Identity) (*wssdcloudsecurity.Identity, error)
 	}
 
 	if id.LoginFilePath != nil && !(filepath.IsAbs(*id.LoginFilePath)) {
+		fmt.Println(*id.LoginFilePath)
 		return nil, errors.Wrapf(errors.InvalidInput, "Identity Loginfile must be absolute filepath")
 	}
 	wssdidentity := &wssdcloudsecurity.Identity{

--- a/services/security/identity/identity.go
+++ b/services/security/identity/identity.go
@@ -4,7 +4,6 @@
 package identity
 
 import (
-	"fmt"
 	"path/filepath"
 
 	"github.com/microsoft/moc-sdk-for-go/services/security"
@@ -59,10 +58,6 @@ func getWssdIdentity(id *security.Identity) (*wssdcloudsecurity.Identity, error)
 		return nil, errors.Wrapf(errors.InvalidInput, "Identity name is missing")
 	}
 
-	if id.LoginFilePath != nil && !(filepath.IsAbs(*id.LoginFilePath)) {
-		fmt.Println(*id.LoginFilePath)
-		return nil, errors.Wrapf(errors.InvalidInput, "Identity Loginfile must be absolute filepath")
-	}
 	wssdidentity := &wssdcloudsecurity.Identity{
 		Name: *id.Name,
 	}
@@ -115,6 +110,17 @@ func getWssdIdentity(id *security.Identity) (*wssdcloudsecurity.Identity, error)
 
 	wssdidentity.ClientType = clitype
 	wssdidentity.AutoRotate = id.AutoRotate
+
+	// In case auto rotate in enabled, the login file path can not be empty or relatively
+	if id.AutoRotate == true && id.LoginFilePath != nil {
+		if *id.LoginFilePath == "" {
+			return nil, errors.Wrapf(errors.InvalidInput, "Identity Loginfile path cannot be empty")
+		}
+		if !(filepath.IsAbs(*id.LoginFilePath)) {
+			return nil, errors.Wrapf(errors.InvalidInput, "Identity Loginfile must be absolute filepath")
+		}
+	}
+
 	if id.LoginFilePath != nil {
 		wssdidentity.LoginFilePath = *id.LoginFilePath
 	}

--- a/services/security/identity/identity.go
+++ b/services/security/identity/identity.go
@@ -111,8 +111,8 @@ func getWssdIdentity(id *security.Identity) (*wssdcloudsecurity.Identity, error)
 	wssdidentity.ClientType = clitype
 	wssdidentity.AutoRotate = id.AutoRotate
 
-	// In case auto rotate in enabled, the login file path can not be relative
-	if id.AutoRotate == true && id.LoginFilePath != nil {
+	// If auto rotate is enabled and login file path is not null and is an empty string
+	if id.AutoRotate == true && id.LoginFilePath != nil && *id.LoginFilePath != "" {
 		if !(filepath.IsAbs(*id.LoginFilePath)) {
 			return nil, errors.Wrapf(errors.InvalidInput, "Identity Loginfile must be absolute filepath")
 		}

--- a/services/security/identity/identity.go
+++ b/services/security/identity/identity.go
@@ -111,11 +111,8 @@ func getWssdIdentity(id *security.Identity) (*wssdcloudsecurity.Identity, error)
 	wssdidentity.ClientType = clitype
 	wssdidentity.AutoRotate = id.AutoRotate
 
-	// In case auto rotate in enabled, the login file path can not be empty or relatively
+	// In case auto rotate in enabled, the login file path can not be relative
 	if id.AutoRotate == true && id.LoginFilePath != nil {
-		if *id.LoginFilePath == "" {
-			return nil, errors.Wrapf(errors.InvalidInput, "Identity Loginfile path cannot be empty")
-		}
 		if !(filepath.IsAbs(*id.LoginFilePath)) {
 			return nil, errors.Wrapf(errors.InvalidInput, "Identity Loginfile must be absolute filepath")
 		}


### PR DESCRIPTION
Updated 2 checks to ensure that if `AutoRotate` is true and `LoginFilePath` is not `nil`, then we check
1. `LoginFilePath` is not an empty string ""
2. `LoginFilePath` is an absolute file path