### PR TITLE
Add health api client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
+	google.golang.org/protobuf v1.30.0
 )
 
 replace (

--- a/pkg/client/admin.go
+++ b/pkg/client/admin.go
@@ -60,3 +60,13 @@ func GetValidationClient(serverAddress *string, authorizer auth.Authorizer) (cad
 
 	return cadmin_pb.NewValidationAgentClient(conn), nil
 }
+
+// GetHealthClient returns the wssdcloudagent health information
+func GetHealthClient(serverAddress *string, authorizer auth.Authorizer) (cadmin_pb.HealthAgentClient, error) {
+	conn, err := getClientConnection(serverAddress, authorizer)
+	if err != nil {
+		log.Fatalf("Unable to get HealthClient. Failed to dial: %v", err)
+	}
+
+	return cadmin_pb.NewHealthAgentClient(conn), nil
+}

--- a/services/admin/health/client.go
+++ b/services/admin/health/client.go
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license
+
+package health
+
+import (
+	"context"
+
+	"github.com/microsoft/moc-sdk-for-go/services/admin/health/internal"
+	"github.com/microsoft/moc/pkg/auth"
+	"github.com/microsoft/moc/rpc/common"
+)
+
+// Service interfacetype Service interface {
+type Service interface {
+	CheckHealth(ctx context.Context, timeoutSeconds uint32) error
+	GetAgentInfo(context.Context) (*common.NodeInfo, error)
+}
+
+// Client structure
+type HealthClient struct {
+	internal Service
+}
+
+// NewClient method returns new client
+func NewHealthClient(cloudFQDN string, authorizer auth.Authorizer) (*HealthClient, error) {
+	c, err := internal.NewHealthClient(cloudFQDN, authorizer)
+	return &HealthClient{c}, err
+}
+
+// CheckHealth
+func (c *HealthClient) CheckHealth(ctx context.Context, timeoutSeconds uint32) error {
+	return c.internal.CheckHealth(ctx, timeoutSeconds)
+}
+
+// GetAgentInfo
+func (c *HealthClient) GetAgentInfo(ctx context.Context) (*common.NodeInfo, error) {
+	return c.internal.GetAgentInfo(ctx)
+}

--- a/services/admin/health/internal/moc.go
+++ b/services/admin/health/internal/moc.go
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license
+
+package internal
+
+import (
+	"context"
+
+	mocclient "github.com/microsoft/moc-sdk-for-go/pkg/client"
+	"github.com/microsoft/moc/pkg/auth"
+	"github.com/microsoft/moc/rpc/common"
+	mocadmin "github.com/microsoft/moc/rpc/common/admin"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type client struct {
+	mocadmin.HealthAgentClient
+}
+
+// NewHealthClient - creates a client session with the backend moc agent
+func NewHealthClient(subID string, authorizer auth.Authorizer) (*client, error) {
+	c, err := mocclient.GetHealthClient(&subID, authorizer)
+	if err != nil {
+		return nil, err
+	}
+	return &client{c}, nil
+}
+
+func (c *client) CheckHealth(ctx context.Context, timeoutSeconds uint32) error {
+	request := mocadmin.HealthRequest{TimeoutSeconds: timeoutSeconds}
+	_, err := c.HealthAgentClient.CheckHealth(ctx, &request)
+	return err
+}
+
+// GetAgentInfo
+func (c *client) GetAgentInfo(ctx context.Context) (*common.NodeInfo, error) {
+	response, err := c.HealthAgentClient.GetAgentInfo(ctx, &emptypb.Empty{})
+	if err != nil {
+		return &common.NodeInfo{}, err
+	}
+	return response.Node, nil
+}


### PR DESCRIPTION
Add client messages for communicating with the health api being added to the cloud agent. Will be used by the moc-operator to query cloud agent uptime. 