### PR TITLE
Add OsVersion to Tags

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -12,4 +12,5 @@ const (
 	CertificateValidityThreshold float64 = (30.0 / 100.0)
 	RenewalBackoff               float64 = (2.0 / 100.0)
 	OsRegistrationStatus         string  = "osRegistrationStatus"
+	OsVersion                    string  = "osVersion"
 )

--- a/services/cloud/node/node.go
+++ b/services/cloud/node/node.go
@@ -81,9 +81,12 @@ func getNodeStatuses(node *wssdcloud.Node) map[string]*string {
 
 func generateNodeTags(node *wssdcloud.Node) map[string]*string {
 	tags := make(map[string]*string)
-	populateOsVersionTag(tags, node)
 	populateOsRegistrationStatusTag(tags, node)
-	return tags
+	populateOsVersionTag(tags, node)
+	if len(tags) > 0 {
+		return tags
+	}
+	return nil
 }
 
 func populateOsRegistrationStatusTag(tags map[string]*string, node *wssdcloud.Node) {

--- a/services/cloud/node/node.go
+++ b/services/cloud/node/node.go
@@ -81,16 +81,20 @@ func getNodeStatuses(node *wssdcloud.Node) map[string]*string {
 
 func generateNodeTags(node *wssdcloud.Node) map[string]*string {
 	tags := make(map[string]*string)
+	populateOsVersionTag(tags, node)
 	populateOsRegistrationStatusTag(tags, node)
-	if len(tags) > 0 {
-		return tags
-	}
-	return nil
+	return tags
 }
 
 func populateOsRegistrationStatusTag(tags map[string]*string, node *wssdcloud.Node) {
 	if node.Info != nil && node.Info.OsInfo != nil && node.Info.OsInfo.OsRegistrationStatus != nil {
 		osRegistrationStatus := strconv.Itoa(int(node.Info.OsInfo.OsRegistrationStatus.Status))
 		tags[constant.OsRegistrationStatus] = &osRegistrationStatus
+	}
+}
+
+func populateOsVersionTag(tags map[string]*string, node *wssdcloud.Node) {
+	if node.Info != nil && node.Info.OsInfo != nil {
+		tags[constant.OsVersion] = &node.Info.OsInfo.Osversion
 	}
 }


### PR DESCRIPTION
1. Add OsVersion to Tags of Node object.
2. Code changes as part of [this](https://msazure.visualstudio.com/DefaultCollection/One/_workitems/edit/25064743) feature.
3. osVersion will be needed in the Operators to check if the Node is pre23H2 or not.
4. 
![MicrosoftTeams-image (11)](https://github.com/microsoft/moc-sdk-for-go/assets/33834843/98518c92-4d4a-4297-bdb6-f73165abd8df)
