### PR TITLE
Fix json property name

### DIFF
--- a/services/network/network.go
+++ b/services/network/network.go
@@ -1060,7 +1060,7 @@ type LogicalSubnetPropertiesFormat struct {
 	// DhcpOptions - The dhcpOptions that contains an array of DNS servers available to VMs deployed in the Logical network.
 	DhcpOptions *DhcpOptions `json:"dhcpOptions,omitempty"`
 	// Public - Gets whether this is a public subnet on a virtual machine.
-	Public *bool `json:"primary,omitempty"`
+	Public *bool `json:"public,omitempty"`
 }
 
 // LogicalSubnet is a subnet in a Logical network resource.


### PR DESCRIPTION
Fixes JSON property name in `LogicalSubnetPropertiesFormat`.  

It is a one-line change to match the json property name with the struct property name.

### Public *bool `json:"public,omitempty"``