### PR TITLE
Add other resource precheck functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.29
 	github.com/Azure/go-autorest/autorest/date v0.3.0
 	github.com/google/uuid v1.4.0
-	github.com/microsoft/moc v0.19.2
+	github.com/microsoft/moc v0.19.3
 	google.golang.org/grpc v1.59.0
 	k8s.io/klog v1.0.0
 )
@@ -24,7 +24,6 @@ replace (
 	github.com/Azure/go-autorest v11.1.2+incompatible => github.com/Azure/go-autorest/autorest v0.10.0
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
-	github.com/microsoft/moc => github.com/microsoft/moc v0.19.2-0.20240621211241-c2bd73cfc238
 	github.com/miekg/dns => github.com/miekg/dns v1.1.25
 	github.com/nats-io/nkeys => github.com/nats-io/nkeys v0.4.6
 	golang.org/x/net => golang.org/x/net v0.0.0-20220822230855-b0a4917ee28c

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ replace (
 	github.com/Azure/go-autorest v11.1.2+incompatible => github.com/Azure/go-autorest/autorest v0.10.0
 	github.com/dgrijalva/jwt-go => github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+	github.com/microsoft/moc => github.com/microsoft/moc v0.19.2-0.20240621211241-c2bd73cfc238
 	github.com/miekg/dns => github.com/miekg/dns v1.1.25
 	github.com/nats-io/nkeys => github.com/nats-io/nkeys v0.4.6
 	golang.org/x/net => golang.org/x/net v0.0.0-20220822230855-b0a4917ee28c

--- a/go.sum
+++ b/go.sum
@@ -1507,8 +1507,8 @@ github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.15/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/microsoft/moc v0.19.2-0.20240621211241-c2bd73cfc238 h1:rCIXMgxIqPkyJ4yAvaXPuXHRaTltYSsvLM6mH9SFoVg=
-github.com/microsoft/moc v0.19.2-0.20240621211241-c2bd73cfc238/go.mod h1:AajC4cQqtCC8IhJd8mD0B/mNGHn7CCoClfb+Cjaum30=
+github.com/microsoft/moc v0.19.3 h1:O17K84eK294C/gDtC8N19NfVql6KKrsk4RbWIGM7oNw=
+github.com/microsoft/moc v0.19.3/go.mod h1:kBKopkA3mhnPrwiA61MBqFg0DkPeTrj40e2Y3k221UM=
 github.com/miekg/dns v1.1.25/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=
@@ -2211,8 +2211,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20231012201019-e917dd12ba7a/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20231016165738-49dd2c1f3d0b/go.mod h1:swOH3j0KzcDDgGUWr+SNpyTen5YrXjS3eyPzFYKc6lc=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20231030173426-d783a09b4405/go.mod h1:67X1fPuzjcrkymZzZV1vvkFeTn2Rvc6lYF9MYFGCcwE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f/go.mod h1:L9KNLi232K1/xB6f7AlSX692koaRnKaWSR0stBki0Yc=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240617180043-68d350f18fd4 h1:Di6ANFilr+S60a4S61ZM00vLdw0IrQOSMS2/6mrnOU0=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20240617180043-68d350f18fd4/go.mod h1:Ue6ibwXGpU+dqIcODieyLOcgj7z8+IcskoNIgZxtrFY=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240624140628-dc46fd24d27d h1:k3zyW3BYYR30e8v3x0bTDdE9vpYFjZHK+HcyqkrppWk=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20240624140628-dc46fd24d27d/go.mod h1:Ue6ibwXGpU+dqIcODieyLOcgj7z8+IcskoNIgZxtrFY=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/go.sum
+++ b/go.sum
@@ -1507,8 +1507,8 @@ github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-sqlite3 v1.14.14/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.15/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/microsoft/moc v0.19.2 h1:DjztLcm7G0UIXxpXPG+hv8VeudfFhs6Fo2vg01OpuvI=
-github.com/microsoft/moc v0.19.2/go.mod h1:AajC4cQqtCC8IhJd8mD0B/mNGHn7CCoClfb+Cjaum30=
+github.com/microsoft/moc v0.19.2-0.20240621211241-c2bd73cfc238 h1:rCIXMgxIqPkyJ4yAvaXPuXHRaTltYSsvLM6mH9SFoVg=
+github.com/microsoft/moc v0.19.2-0.20240621211241-c2bd73cfc238/go.mod h1:AajC4cQqtCC8IhJd8mD0B/mNGHn7CCoClfb+Cjaum30=
 github.com/miekg/dns v1.1.25/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8/go.mod h1:mC1jAcsrzbxHt8iiaC+zU4b1ylILSosueou12R++wfY=
 github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3/go.mod h1:RagcQ7I8IeTMnF8JTXieKnO4Z6JCsikNEzj0DwauVzE=

--- a/services/compute/availabilityset/client.go
+++ b/services/compute/availabilityset/client.go
@@ -14,6 +14,7 @@ type Service interface {
 	Get(context.Context, string, string) (*[]compute.AvailabilitySet, error)
 	Create(ctx context.Context, group string, name string, avset *compute.AvailabilitySet) (*compute.AvailabilitySet, error)
 	Delete(context.Context, string, string) error
+	Precheck(ctx context.Context, group string, avsets []*compute.AvailabilitySet) (bool, error)
 }
 
 type AvailabilitySetClient struct {
@@ -43,4 +44,10 @@ func (c *AvailabilitySetClient) Create(ctx context.Context, group, name string, 
 // Delete methods invokes delete of the compute resource
 func (c *AvailabilitySetClient) Delete(ctx context.Context, group, name string) error {
 	return c.internal.Delete(ctx, group, name)
+}
+
+// Prechecks whether the system is able to create specified availability sets.
+// Returns true if it is possible; or false with reason in error message if not.
+func (c *AvailabilitySetClient) Precheck(ctx context.Context, group string, avsets []*compute.AvailabilitySet) (bool, error) {
+	return c.internal.Precheck(ctx, group, avsets)
 }

--- a/services/compute/galleryimage/client.go
+++ b/services/compute/galleryimage/client.go
@@ -17,6 +17,7 @@ type Service interface {
 	Get(context.Context, string, string) (*[]compute.GalleryImage, error)
 	CreateOrUpdate(context.Context, string, string, string, *compute.GalleryImage) (*compute.GalleryImage, error)
 	Delete(context.Context, string, string) error
+	Precheck(ctx context.Context, location, imagePath string, galleryImages []*compute.GalleryImage) (bool, error)
 }
 
 // Client structure
@@ -51,6 +52,12 @@ func (c *GalleryImageClient) CreateOrUpdate(ctx context.Context, location, image
 // Delete methods invokes delete of the compute resource
 func (c *GalleryImageClient) Delete(ctx context.Context, location, name string) error {
 	return c.internal.Delete(ctx, location, name)
+}
+
+// Prechecks whether the system is able to create specified resources.
+// Returns true if it is possible; or false with reason in error message if not.
+func (c *GalleryImageClient) Precheck(ctx context.Context, location, imagePath string, galleryImages []*compute.GalleryImage) (bool, error) {
+	return c.internal.Precheck(ctx, location, imagePath, galleryImages)
 }
 
 // UploadImageFromLocal   methods invokes  UploadImageFromLocal  on the client

--- a/services/compute/virtualmachineimage/client.go
+++ b/services/compute/virtualmachineimage/client.go
@@ -5,6 +5,7 @@ package virtualmachineimage
 
 import (
 	"context"
+
 	"github.com/microsoft/moc-sdk-for-go/services/compute"
 	"github.com/microsoft/moc/pkg/auth"
 )
@@ -14,6 +15,7 @@ type Service interface {
 	Get(context.Context, string, string) (*[]compute.VirtualMachineImage, error)
 	CreateOrUpdate(context.Context, string, string, *compute.VirtualMachineImage) (*compute.VirtualMachineImage, error)
 	Delete(context.Context, string, string) error
+	Precheck(ctx context.Context, group string, virtualMachineImages []*compute.VirtualMachineImage) (bool, error)
 }
 
 // Client structure
@@ -45,4 +47,10 @@ func (c *VirtualMachineImageClient) CreateOrUpdate(ctx context.Context, group, n
 // Delete methods invokes delete of the compute resource
 func (c *VirtualMachineImageClient) Delete(ctx context.Context, group, name string) error {
 	return c.internal.Delete(ctx, group, name)
+}
+
+// Prechecks whether the system is able to create specified virtualMachineImages.
+// Returns true if it is possible; or false with reason in error message if not.
+func (c *VirtualMachineImageClient) Precheck(ctx context.Context, group string, virtualMachineImages []*compute.VirtualMachineImage) (bool, error) {
+	return c.internal.Precheck(ctx, group, virtualMachineImages)
 }

--- a/services/network/loadbalancer/client.go
+++ b/services/network/loadbalancer/client.go
@@ -15,6 +15,7 @@ type Service interface {
 	Get(context.Context, string, string) (*[]network.LoadBalancer, error)
 	CreateOrUpdate(context.Context, string, string, *network.LoadBalancer) (*network.LoadBalancer, error)
 	Delete(context.Context, string, string) error
+	Precheck(ctx context.Context, group string, loadBalancers []*network.LoadBalancer) (bool, error)
 }
 
 // LoadBalancerClient structure
@@ -46,4 +47,10 @@ func (c *LoadBalancerClient) CreateOrUpdate(ctx context.Context, group, name str
 // Delete methods invokes delete of the network resource
 func (c *LoadBalancerClient) Delete(ctx context.Context, group, name string) error {
 	return c.internal.Delete(ctx, group, name)
+}
+
+// Prechecks whether the system is able to create specified loadBalancers.
+// Returns true if it is possible; or false with reason in error message if not.
+func (c *LoadBalancerClient) Precheck(ctx context.Context, group string, loadBalancers []*network.LoadBalancer) (bool, error) {
+	return c.internal.Precheck(ctx, group, loadBalancers)
 }

--- a/services/network/logicalnetwork/client.go
+++ b/services/network/logicalnetwork/client.go
@@ -15,6 +15,7 @@ type Service interface {
 	Get(context.Context, string, string) (*[]network.LogicalNetwork, error)
 	CreateOrUpdate(context.Context, string, string, *network.LogicalNetwork) (*network.LogicalNetwork, error)
 	Delete(context.Context, string, string) error
+	Precheck(ctx context.Context, location string, logicalNetworks []*network.LogicalNetwork) (bool, error)
 }
 
 // Client structure
@@ -46,4 +47,10 @@ func (c *LogicalNetworkClient) CreateOrUpdate(ctx context.Context, location, nam
 // Delete methods invokes delete of the logical network resource
 func (c *LogicalNetworkClient) Delete(ctx context.Context, location, name string) error {
 	return c.internal.Delete(ctx, location, name)
+}
+
+// Prechecks whether the system is able to create specified logicalNetworks.
+// Returns true if it is possible; or false with reason in error message if not.
+func (c *LogicalNetworkClient) Precheck(ctx context.Context, location string, logicalNetworks []*network.LogicalNetwork) (bool, error) {
+	return c.internal.Precheck(ctx, location, logicalNetworks)
 }

--- a/services/network/macpool/client.go
+++ b/services/network/macpool/client.go
@@ -15,6 +15,7 @@ type Service interface {
 	Get(context.Context, string, string) (*[]network.MACPool, error)
 	CreateOrUpdate(context.Context, string, string, *network.MACPool) (*network.MACPool, error)
 	Delete(context.Context, string, string) error
+	Precheck(ctx context.Context, location string, macPools []*network.MACPool) (bool, error)
 }
 
 // MacPoolClient structure
@@ -46,4 +47,10 @@ func (c *MacPoolClient) CreateOrUpdate(ctx context.Context, location, name strin
 // Delete methods invokes delete of the network resource
 func (c *MacPoolClient) Delete(ctx context.Context, location, name string) error {
 	return c.internal.Delete(ctx, location, name)
+}
+
+// Prechecks whether the system is able to create specified resources.
+// Returns true if it is possible; or false with reason in error message if not.
+func (c *MacPoolClient) Precheck(ctx context.Context, location string, macPools []*network.MACPool) (bool, error) {
+	return c.internal.Precheck(ctx, location, macPools)
 }

--- a/services/network/networkinterface/client.go
+++ b/services/network/networkinterface/client.go
@@ -5,6 +5,7 @@ package networkinterface
 
 import (
 	"context"
+
 	"github.com/microsoft/moc-sdk-for-go/services/network"
 	"github.com/microsoft/moc/pkg/auth"
 )
@@ -14,6 +15,7 @@ type Service interface {
 	Get(context.Context, string, string) (*[]network.Interface, error)
 	CreateOrUpdate(context.Context, string, string, *network.Interface) (*network.Interface, error)
 	Delete(context.Context, string, string) error
+	Precheck(ctx context.Context, group string, networkInterfaces []*network.Interface) (bool, error)
 }
 
 // InterfaceClient structure
@@ -45,4 +47,10 @@ func (c *InterfaceClient) CreateOrUpdate(ctx context.Context, group, name string
 // Delete methods invokes delete of the network interface resource
 func (c *InterfaceClient) Delete(ctx context.Context, group, name string) error {
 	return c.internal.Delete(ctx, group, name)
+}
+
+// Prechecks whether the system is able to create specified resources.
+// Returns true if it is possible; or false with reason in error message if not.
+func (c *InterfaceClient) Precheck(ctx context.Context, group string, networkInterfaces []*network.Interface) (bool, error) {
+	return c.internal.Precheck(ctx, group, networkInterfaces)
 }

--- a/services/network/networkinterface/wssd.go
+++ b/services/network/networkinterface/wssd.go
@@ -6,6 +6,7 @@ package networkinterface
 import (
 	"context"
 	"fmt"
+
 	wssdcloudclient "github.com/microsoft/moc-sdk-for-go/pkg/client"
 	"github.com/microsoft/moc-sdk-for-go/services/network"
 	"github.com/microsoft/moc/pkg/auth"
@@ -88,6 +89,18 @@ func (c *client) Delete(ctx context.Context, group, name string) error {
 	return err
 }
 
+func (c *client) Precheck(ctx context.Context, group string, resources []*network.Interface) (bool, error) {
+	request, err := getNetworkInterfacePrecheckRequest(group, resources)
+	if err != nil {
+		return false, err
+	}
+	response, err := c.NetworkInterfaceAgentClient.Precheck(ctx, request)
+	if err != nil {
+		return false, err
+	}
+	return getNetworkInterfacePrecheckResponse(response)
+}
+
 // ///////////// private methods  ///////////////
 func (c *client) getNetworkInterfaceRequest(opType wssdcloudcommon.Operation, group, name string, networkInterface *network.Interface) (*wssdcloudnetwork.NetworkInterfaceRequest, error) {
 	request := &wssdcloudnetwork.NetworkInterfaceRequest{
@@ -129,4 +142,32 @@ func (c *client) getInterfacesFromResponse(group string, response *wssdcloudnetw
 	}
 
 	return &virtualNetworkInterfaces, nil
+}
+
+func getNetworkInterfacePrecheckRequest(group string, networkInterfaces []*network.Interface) (*wssdcloudnetwork.NetworkInterfacePrecheckRequest, error) {
+	request := &wssdcloudnetwork.NetworkInterfacePrecheckRequest{}
+
+	protoNetworkInterfaces := make([]*wssdcloudnetwork.NetworkInterface, 0, len(networkInterfaces))
+
+	for _, networkInterface := range networkInterfaces {
+		// can networkInterface ever be nil here? what would be the meaning of that?
+		if networkInterface != nil {
+			protoNetworkInterface, err := getWssdNetworkInterface(networkInterface, group)
+			if err != nil {
+				return nil, errors.Wrap(err, "unable to convert NetworkInterface to Protobuf representation")
+			}
+			protoNetworkInterfaces = append(protoNetworkInterfaces, protoNetworkInterface)
+		}
+	}
+
+	request.NetworkInterfaces = protoNetworkInterfaces
+	return request, nil
+}
+
+func getNetworkInterfacePrecheckResponse(response *wssdcloudnetwork.NetworkInterfacePrecheckResponse) (bool, error) {
+	result := response.GetResult().GetValue()
+	if !result {
+		return result, errors.New(response.GetError())
+	}
+	return result, nil
 }

--- a/services/network/networksecuritygroup/client.go
+++ b/services/network/networksecuritygroup/client.go
@@ -15,6 +15,7 @@ type Service interface {
 	Get(context.Context, string, string) (*[]network.SecurityGroup, error)
 	CreateOrUpdate(context.Context, string, string, *network.SecurityGroup) (*network.SecurityGroup, error)
 	Delete(context.Context, string, string) error
+	Precheck(ctx context.Context, location string, networkSecurityGroups []*network.SecurityGroup) (bool, error)
 }
 
 // NetworkSecurityGroupAgentClient structure
@@ -46,4 +47,10 @@ func (c *NetworkSecurityGroupAgentClient) CreateOrUpdate(ctx context.Context, lo
 // Delete methods invokes delete of the network resource
 func (c *NetworkSecurityGroupAgentClient) Delete(ctx context.Context, location, name string) error {
 	return c.internal.Delete(ctx, location, name)
+}
+
+// Prechecks whether the system is able to create specified resources.
+// Returns true if it is possible; or false with reason in error message if not.
+func (c *NetworkSecurityGroupAgentClient) Precheck(ctx context.Context, location string, networkSecurityGroups []*network.SecurityGroup) (bool, error) {
+	return c.internal.Precheck(ctx, location, networkSecurityGroups)
 }

--- a/services/network/vippool/client.go
+++ b/services/network/vippool/client.go
@@ -15,6 +15,7 @@ type Service interface {
 	Get(context.Context, string, string) (*[]network.VipPool, error)
 	CreateOrUpdate(context.Context, string, string, *network.VipPool) (*network.VipPool, error)
 	Delete(context.Context, string, string) error
+	Precheck(ctx context.Context, location string, resources []*network.VipPool) (bool, error)
 }
 
 // VipPoolClient structure
@@ -46,4 +47,10 @@ func (c *VipPoolClient) CreateOrUpdate(ctx context.Context, location, name strin
 // Delete methods invokes delete of the network resource
 func (c *VipPoolClient) Delete(ctx context.Context, location, name string) error {
 	return c.internal.Delete(ctx, location, name)
+}
+
+// Prechecks whether the system is able to create specified resources.
+// Returns true if it is possible; or false with reason in error message if not.
+func (c *VipPoolClient) Precheck(ctx context.Context, location string, resources []*network.VipPool) (bool, error) {
+	return c.internal.Precheck(ctx, location, resources)
 }

--- a/services/network/virtualnetwork/client.go
+++ b/services/network/virtualnetwork/client.go
@@ -5,6 +5,7 @@ package virtualnetwork
 
 import (
 	"context"
+
 	"github.com/microsoft/moc-sdk-for-go/services/network"
 	"github.com/microsoft/moc/pkg/auth"
 )
@@ -14,6 +15,7 @@ type Service interface {
 	Get(context.Context, string, string) (*[]network.VirtualNetwork, error)
 	CreateOrUpdate(context.Context, string, string, *network.VirtualNetwork) (*network.VirtualNetwork, error)
 	Delete(context.Context, string, string) error
+	Precheck(ctx context.Context, group string, virtualNetworks []*network.VirtualNetwork) (bool, error)
 }
 
 // Client structure
@@ -45,4 +47,10 @@ func (c *VirtualNetworkClient) CreateOrUpdate(ctx context.Context, group, name s
 // Delete methods invokes delete of the network resource
 func (c *VirtualNetworkClient) Delete(ctx context.Context, group, name string) error {
 	return c.internal.Delete(ctx, group, name)
+}
+
+// Prechecks whether the system is able to create specified resources.
+// Returns true if it is possible; or false with reason in error message if not.
+func (c *VirtualNetworkClient) Precheck(ctx context.Context, group string, virtualNetworks []*network.VirtualNetwork) (bool, error) {
+	return c.internal.Precheck(ctx, group, virtualNetworks)
 }

--- a/services/security/certificate/client.go
+++ b/services/security/certificate/client.go
@@ -17,6 +17,7 @@ type Service interface {
 	Delete(context.Context, string, string) error
 	Sign(context.Context, string, string, *security.CertificateRequest) (*security.Certificate, string, error)
 	Renew(context.Context, string, string, *security.CertificateRequest) (*security.Certificate, string, error)
+	Precheck(ctx context.Context, certificates []*security.Certificate) (bool, error)
 }
 
 // Client structure
@@ -58,4 +59,10 @@ func (c *CertificateClient) Sign(ctx context.Context, group, name string, csr *s
 // Renew methods invokes renew to renew signed-certificate
 func (c *CertificateClient) Renew(ctx context.Context, group, name string, csr *security.CertificateRequest) (*security.Certificate, string, error) {
 	return c.internal.Renew(ctx, group, name, csr)
+}
+
+// Prechecks whether the system is able to create specified resources.
+// Returns true if it is possible; or false with reason in error message if not.
+func (c *CertificateClient) Precheck(ctx context.Context, certificates []*security.Certificate) (bool, error) {
+	return c.internal.Precheck(ctx, certificates)
 }

--- a/services/security/identity/client.go
+++ b/services/security/identity/client.go
@@ -19,6 +19,7 @@ type Service interface {
 	Rotate(context.Context, string, string) (*security.Identity, error)
 	CreateCertificate(context.Context, string, string, []*security.CertificateRequest) ([]*security.Certificate, string, error)
 	RenewCertificate(context.Context, string, string, []*security.CertificateRequest) ([]*security.Certificate, string, error)
+	Precheck(ctx context.Context, identities []*security.Identity) (bool, error)
 }
 
 // Client structure
@@ -70,4 +71,10 @@ func (c *IdentityClient) CreateCertificate(ctx context.Context, group, name stri
 // RenewCertificate methods invokes renew client certificate for the identity
 func (c *IdentityClient) RenewCertificate(ctx context.Context, group, name string, csr []*security.CertificateRequest) ([]*security.Certificate, string, error) {
 	return c.internal.RenewCertificate(ctx, group, name, csr)
+}
+
+// Prechecks whether the system is able to create specified resources.
+// Returns true if it is possible; or false with reason in error message if not.
+func (c *IdentityClient) Precheck(ctx context.Context, identities []*security.Identity) (bool, error) {
+	return c.internal.Precheck(ctx, identities)
 }

--- a/services/security/identity/wssd.go
+++ b/services/security/identity/wssd.go
@@ -287,7 +287,7 @@ func getIdentityPrecheckRequest(identities []*security.Identity) (*wssdcloudsecu
 		}
 	}
 
-	request.Identitys = protoIdentities
+	request.Identities = protoIdentities
 	return request, nil
 }
 

--- a/services/security/identity/wssd.go
+++ b/services/security/identity/wssd.go
@@ -183,6 +183,18 @@ func (c *client) RenewCertificate(ctx context.Context, group, name string, csrs 
 	return certs, key, nil
 }
 
+func (c *client) Precheck(ctx context.Context, identities []*security.Identity) (bool, error) {
+	request, err := getIdentityPrecheckRequest(identities)
+	if err != nil {
+		return false, err
+	}
+	response, err := c.IdentityAgentClient.Precheck(ctx, request)
+	if err != nil {
+		return false, err
+	}
+	return getIdentityPrecheckResponse(response)
+}
+
 func getIdentitysFromResponse(response *wssdcloudsecurity.IdentityResponse) *[]security.Identity {
 	certs := []security.Identity{}
 	for _, identitys := range response.GetIdentitys() {
@@ -257,4 +269,32 @@ func getCertificatesFromResponse(response *wssdcloudsecurity.IdentityCertificate
 		certificates = append(certificates, certificate.GetCertificate(wssdCert))
 	}
 	return certificates
+}
+
+func getIdentityPrecheckRequest(identities []*security.Identity) (*wssdcloudsecurity.IdentityPrecheckRequest, error) {
+	request := &wssdcloudsecurity.IdentityPrecheckRequest{}
+
+	protoIdentities := make([]*wssdcloudsecurity.Identity, 0, len(identities))
+
+	for _, identity := range identities {
+		// can identity ever be nil here? what would be the meaning of that?
+		if identity != nil {
+			protoIdentity, err := getWssdIdentity(identity)
+			if err != nil {
+				return nil, errors.Wrap(err, "unable to convert Identity to Protobuf representation")
+			}
+			protoIdentities = append(protoIdentities, protoIdentity)
+		}
+	}
+
+	request.Identitys = protoIdentities
+	return request, nil
+}
+
+func getIdentityPrecheckResponse(response *wssdcloudsecurity.IdentityPrecheckResponse) (bool, error) {
+	result := response.GetResult().GetValue()
+	if !result {
+		return result, errors.New(response.GetError())
+	}
+	return result, nil
 }

--- a/services/storage/container/client.go
+++ b/services/storage/container/client.go
@@ -15,6 +15,7 @@ type Service interface {
 	Get(context.Context, string, string) (*[]storage.Container, error)
 	CreateOrUpdate(context.Context, string, string, *storage.Container) (*storage.Container, error)
 	Delete(context.Context, string, string) error
+	Precheck(ctx context.Context, location string, containers []*storage.Container) (bool, error)
 }
 
 // Client structure
@@ -46,4 +47,10 @@ func (c *ContainerClient) CreateOrUpdate(ctx context.Context, location, name str
 // Delete methods invokes delete of the storage resource
 func (c *ContainerClient) Delete(ctx context.Context, location, name string) error {
 	return c.internal.Delete(ctx, location, name)
+}
+
+// Prechecks whether the system is able to create specified resources.
+// Returns true if it is possible; or false with reason in error message if not.
+func (c *ContainerClient) Precheck(ctx context.Context, location string, containers []*storage.Container) (bool, error) {
+	return c.internal.Precheck(ctx, location, containers)
 }


### PR DESCRIPTION
# Changes introduced by this PR
- Add Precheck helper functions that call the corresponding new precheck RPC introduced in https://github.com/microsoft/moc/pull/269 for the following services:
- Identity (security)
- Availability set (compute)
- Gallery image (compute)
- Virtual machine image (compute)
- Load balancer (network)
- Logical network (network)
- MAC pool (network)
- Network interface (network)
- Network security group (network)
- VIP pool (network)
- Virtual network (network)
- Container (storage)

# Test plan
Have sanity checked the new precheck API for the storage container resource including cloudagent and moc-sdk-for-go changes. Since the Precheck RPC definition is common except for the resource types, I think this is a sufficient minimum of testing.
