### PR TITLE
Several bug fixes

### DIFF
--- a/services/compute/compute.go
+++ b/services/compute/compute.go
@@ -31,6 +31,7 @@ type OperatingSystemBootstrapEngine string
 const (
 	CloudInit          OperatingSystemBootstrapEngine = "CloudInit"
 	WindowsAnswerFiles OperatingSystemBootstrapEngine = "WindowsAnswerFiles"
+	Hydrated 		   OperatingSystemBootstrapEngine = "Hydrated"
 )
 
 type VMType string

--- a/services/compute/virtualmachine/virtualmachine.go
+++ b/services/compute/virtualmachine/virtualmachine.go
@@ -871,6 +871,8 @@ func (c *client) getVirtualMachineOSProfile(o *wssdcloudcompute.OperatingSystemC
 
 	osBootstrapEngine := compute.CloudInit
 	switch o.OsBootstrapEngine {
+	case wssdcommon.OperatingSystemBootstrapEngine_HYDRATED:
+		osBootstrapEngine = compute.Hydrated
 	case wssdcommon.OperatingSystemBootstrapEngine_WINDOWS_ANSWER_FILES:
 		osBootstrapEngine = compute.WindowsAnswerFiles
 	case wssdcommon.OperatingSystemBootstrapEngine_CLOUD_INIT:


### PR DESCRIPTION
These related PRs fix several issues:
- Creating placeholders during the OS disk hydration failed (see https://msazure.visualstudio.com/One/_workitems/edit/29443919)
  - This happened as we are calling into the create code for the disk placeholders. That code constructs the filename from the name (which in a OS disk hydration is "my_disk-OsDisk", which is *not* the filename). So, we pass through the path to the create code and make sure to use that if it's given and construct the filename from the name otherwise
- Creating the VM placeholders during a VM hydration failed
  - The VM placeholders, like the disk placeholders, use the create flow. However, we set the bootstrap engine to cloudinit during the hydration for VMs, which caused the create flow to try to create a `seed.iso` and related files as it didn't find those files already. When hydrating a VM, it's by definition already running and bootstrapped, so we should denote this in the store representation. We have added a new state "hydrated" to the bootstrap engine field so that we skip any validation or actual bootstrapping during the create flow for the placeholders.
- In moccli, we were constructing the decorated name as `<vm name>_subscription-id_resource-group`. However, if we are using a Linux VM, we have some validation that Linux hostnames are not allowed to have underscores. So this default name got changed to `<vm name>-subscription-id-resource-group`