### PR TITLE
Display VM attached to vNIC to understand if a vNIC is attached to a VM

### DIFF
--- a/services/network/network.go
+++ b/services/network/network.go
@@ -896,7 +896,7 @@ type PrivateEndpoint struct {
 // InterfacePropertiesFormat networkInterface properties.
 type InterfacePropertiesFormat struct {
 	// VirtualMachine - READ-ONLY; The reference of a virtual machine.
-	VirtualMachine *SubResource `json:"virtualMachine,omitempty"`
+	VirtualMachine *string `json:"virtualMachine,omitempty"`
 	// PrivateEndpoint - READ-ONLY; A reference to the private endpoint to which the network interface is linked.
 	PrivateEndpoint *PrivateEndpoint `json:"privateEndpoint,omitempty"`
 	// IPConfigurations - A list of IPConfigurations of the network interface.

--- a/services/network/networkinterface/networkinterface.go
+++ b/services/network/networkinterface/networkinterface.go
@@ -202,6 +202,7 @@ func getNetworkInterface(server, group string, c *wssdcloudnetwork.NetworkInterf
 			Statuses:                    status.GetStatuses(c.GetStatus()),
 			EnableAcceleratedNetworking: getIovSetting(c),
 			DNSSettings:                 getWssdDNSSettings(c.Dns),
+			VirtualMachine:              &c.VirtualMachineName,
 		},
 		Tags: tags.ProtoToMap(c.Tags),
 	}


### PR DESCRIPTION
We currently do not display the VM name field on the vNIC object. This made it difficult to identify if a vNIC is attached a VM during debugging on the customer environments. This PR enables the display of the VM name field on the vNIC object.