### PR TITLE
Remove check for Virtual Machine Existence upon Deletion (v25)

### DIFF
--- a/services/compute/virtualmachine/wssd.go
+++ b/services/compute/virtualmachine/wssd.go
@@ -79,20 +79,11 @@ func (c *client) CreateOrUpdate(ctx context.Context, group, name string, sg *com
 
 // Delete methods invokes create or update on the client
 func (c *client) Delete(ctx context.Context, group, name string) error {
-	vm, err := c.Get(ctx, group, name)
-	if err != nil {
-		return err
-	}
-	if len(*vm) == 0 {
-		return fmt.Errorf("Virtual Machine [%s] not found", name)
-	}
-
-	request, err := c.getVirtualMachineRequest(wssdcloudproto.Operation_DELETE, group, name, &(*vm)[0])
+	request, err := c.getVirtualMachineRequest(wssdcloudproto.Operation_DELETE, group, name, nil)
 	if err != nil {
 		return err
 	}
 	_, err = c.VirtualMachineAgentClient.Invoke(ctx, request)
-
 	return err
 }
 


### PR DESCRIPTION
Always issue RPC call for Virtual Machine deletion, even if VM does not exist.
Cherry-pick of https://github.com/microsoft/moc-sdk-for-go/pull/317