### PR TITLE
Modify go version in go.mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ export GO111MODULE=on
 
 PKG := 
 
-all: format  build unittest
+all: vendor format build unittest
 
 clean:
 	rm -rf ${OUT} ${OUTEXE} 

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,6 @@ unittest:
 	GOARCH=amd64 go test -v ./services/security/...
 
 
-golangci-lint:
+golangci-lint: vendor
 	$(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	$(GOPATH_BIN)/golangci-lint run --config .golangci.yml

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/moc-sdk-for-go
 
-go 1.23.0
+go 1.23
 
 require (
 	code.cloudfoundry.org/bytefmt v0.0.0-20210608160410-67692ebc98de


### PR DESCRIPTION
Go.mod will specify major.minor version (1.31) of go. patch version is not accepted (1.31.0), so remove the patch version.  