### PR TITLE
Bump github.com/microsoft/moc to v0.43.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/microsoft/moc v0.43.0
+	github.com/microsoft/moc v0.43.1
 	google.golang.org/grpc v1.79.3
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/klog v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0V
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/microsoft/moc v0.43.0 h1:j7Zu1mBabhD8oOKcf2D5lGa/3KdZmCkt/HpnqvJziGI=
-github.com/microsoft/moc v0.43.0/go.mod h1:MfHHoByGbhXN/E4UXWV8gL0gzhr81zD3I6ZSiwsqjZs=
+github.com/microsoft/moc v0.43.1 h1:zy328gtnoi8H3cc6QD938R6TCYvlZQ7LNA8ME3rzDPs=
+github.com/microsoft/moc v0.43.1/go.mod h1:HrYQ7QUQ+OvS4s43Xc7Xj/rbCyqvwvGeukr8UvgeZhk=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
## Summary
Bump `github.com/microsoft/moc` from v0.43.0 to v0.43.1.

## Dependencies
- microsoft/moc#437 — restores `google.golang.org/grpc` to v1.79.3 (CVE fix that was accidentally undone in v0.43.0).

## Testing
- `go build ./...` ✅
- `go.mod` / `go.sum` only, no code changes.