### PR TITLE
Add UploadImageFromAzureStorageBlob gallery image method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Azure/go-autorest/autorest/date v0.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
-	github.com/microsoft/moc v0.43.1
+	github.com/microsoft/moc v0.43.2
 	google.golang.org/grpc v1.79.3
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/klog v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0V
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/microsoft/moc v0.43.1 h1:zy328gtnoi8H3cc6QD938R6TCYvlZQ7LNA8ME3rzDPs=
-github.com/microsoft/moc v0.43.1/go.mod h1:HrYQ7QUQ+OvS4s43Xc7Xj/rbCyqvwvGeukr8UvgeZhk=
+github.com/microsoft/moc v0.43.2 h1:bFdl9qpzvIzeck9OPkvR/xf6wNENh7253s6meyJB4HE=
+github.com/microsoft/moc v0.43.2/go.mod h1:HrYQ7QUQ+OvS4s43Xc7Xj/rbCyqvwvGeukr8UvgeZhk=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/services/compute/compute.go
+++ b/services/compute/compute.go
@@ -852,6 +852,15 @@ type CloneImageProperties struct {
 	CloneSource string `json:"cloneSource,omitempty"`
 }
 
+// AzureBlobImage properties for downloading images from Azure Storage Blob
+type AzureBlobImageProperties struct {
+	Version     string `json:"version,omitempty"`
+	ReleaseName string `json:"releasename,omitempty"`
+	Parts       int32  `json:"parts,omitempty"`
+	Cloud       string `json:"cloud,omitempty"`
+	Endpoint    string `json:"endpoint,omitempty"`
+}
+
 // Azure GalleryImage properties
 type AzureGalleryImageProperties struct {
 	// SasURL - Specifies the SAS URI for the image

--- a/services/compute/compute.go
+++ b/services/compute/compute.go
@@ -854,8 +854,10 @@ type CloneImageProperties struct {
 
 // AzureBlobImage properties for downloading images from Azure Storage Blob
 type AzureBlobImageProperties struct {
+	CatalogName string `json:"catalogName,omitempty"`
+	Audience    string `json:"audience,omitempty"`
 	Version     string `json:"version,omitempty"`
-	ReleaseName string `json:"releasename,omitempty"`
+	ReleaseName string `json:"releaseName,omitempty"`
 	Parts       int32  `json:"parts,omitempty"`
 	Cloud       string `json:"cloud,omitempty"`
 	Endpoint    string `json:"endpoint,omitempty"`

--- a/services/compute/compute.go
+++ b/services/compute/compute.go
@@ -858,7 +858,7 @@ type AzureBlobImageProperties struct {
 	Audience    string `json:"audience,omitempty"`
 	Version     string `json:"version,omitempty"`
 	ReleaseName string `json:"releaseName,omitempty"`
-	Parts       int32  `json:"parts,omitempty"`
+	Parts       uint32  `json:"parts,omitempty"`
 	Cloud       string `json:"cloud,omitempty"`
 	Endpoint    string `json:"endpoint,omitempty"`
 }

--- a/services/compute/galleryimage/client.go
+++ b/services/compute/galleryimage/client.go
@@ -94,3 +94,16 @@ func (c *GalleryImageClient) UploadImageFromHttp(ctx context.Context, location, 
 	}
 	return c.internal.CreateOrUpdate(ctx, location, string(data), name, galImage)
 }
+
+// UploadImageFromAzureStorageBlob provisions an image via Azure Storage Blob download
+// TODO: Update go.mod to pin github.com/microsoft/moc to a version containing AZURESTORAGEBLOB_SOURCE enum (>= the moc PR merge)
+func (c *GalleryImageClient) UploadImageFromAzureStorageBlob(ctx context.Context, location, name string, galImage *compute.GalleryImage, blobImg *compute.AzureBlobImageProperties) (*compute.GalleryImage, error) {
+	data, err := json.Marshal(blobImg)
+	if err != nil {
+		return nil, err
+	}
+	if galImage != nil && galImage.GalleryImageProperties != nil {
+		galImage.SourceType = common.ImageSource_AZURESTORAGEBLOB_SOURCE
+	}
+	return c.internal.CreateOrUpdate(ctx, location, string(data), name, galImage)
+}

--- a/services/compute/galleryimage/client.go
+++ b/services/compute/galleryimage/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/microsoft/moc-sdk-for-go/services/compute"
 	"github.com/microsoft/moc/pkg/auth"
+	"github.com/microsoft/moc/pkg/errors"
 	"github.com/microsoft/moc/rpc/common"
 )
 
@@ -96,14 +97,14 @@ func (c *GalleryImageClient) UploadImageFromHttp(ctx context.Context, location, 
 }
 
 // UploadImageFromAzureStorageBlob provisions an image via Azure Storage Blob download
-// TODO: Update go.mod to pin github.com/microsoft/moc to a version containing AZURESTORAGEBLOB_SOURCE enum (>= the moc PR merge)
 func (c *GalleryImageClient) UploadImageFromAzureStorageBlob(ctx context.Context, location, name string, galImage *compute.GalleryImage, blobImg *compute.AzureBlobImageProperties) (*compute.GalleryImage, error) {
+	if galImage == nil || galImage.GalleryImageProperties == nil {
+		return nil, errors.Wrapf(errors.InvalidInput, "GalleryImage and GalleryImageProperties are required")
+	}
 	data, err := json.Marshal(blobImg)
 	if err != nil {
 		return nil, err
 	}
-	if galImage != nil && galImage.GalleryImageProperties != nil {
-		galImage.SourceType = common.ImageSource_AZURESTORAGEBLOB_SOURCE
-	}
+	galImage.SourceType = common.ImageSource_AZURESTORAGEBLOB_SOURCE
 	return c.internal.CreateOrUpdate(ctx, location, string(data), name, galImage)
 }

--- a/services/compute/galleryimage/client.go
+++ b/services/compute/galleryimage/client.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/microsoft/moc-sdk-for-go/services/compute"
 	"github.com/microsoft/moc/pkg/auth"
-	"github.com/microsoft/moc/pkg/errors"
 	"github.com/microsoft/moc/rpc/common"
 )
 
@@ -98,13 +97,12 @@ func (c *GalleryImageClient) UploadImageFromHttp(ctx context.Context, location, 
 
 // UploadImageFromAzureStorageBlob provisions an image via Azure Storage Blob download
 func (c *GalleryImageClient) UploadImageFromAzureStorageBlob(ctx context.Context, location, name string, galImage *compute.GalleryImage, blobImg *compute.AzureBlobImageProperties) (*compute.GalleryImage, error) {
-	if galImage == nil || galImage.GalleryImageProperties == nil {
-		return nil, errors.Wrapf(errors.InvalidInput, "GalleryImage and GalleryImageProperties are required")
-	}
 	data, err := json.Marshal(blobImg)
 	if err != nil {
 		return nil, err
 	}
-	galImage.SourceType = common.ImageSource_AZURESTORAGEBLOB_SOURCE
+	if galImage != nil && galImage.GalleryImageProperties != nil {
+		galImage.SourceType = common.ImageSource_AZURESTORAGEBLOB_SOURCE
+	}
 	return c.internal.CreateOrUpdate(ctx, location, string(data), name, galImage)
 }

--- a/services/compute/galleryimage/client_test.go
+++ b/services/compute/galleryimage/client_test.go
@@ -82,21 +82,18 @@ func TestUploadImageFromAzureStorageBlob_SetsSourceTypeAndEncodesJSON(t *testing
 	assert.Equal(t, *blobImg, roundTrip)
 }
 
-func TestUploadImageFromAzureStorageBlob_NilPropertiesDoesNotSetSourceType(t *testing.T) {
+func TestUploadImageFromAzureStorageBlob_NilPropertiesReturnsError(t *testing.T) {
 	fake := &fakeInternal{}
 	c := &GalleryImageClient{internal: fake}
 
-	// galImage without GalleryImageProperties: the wrapper must NOT attempt to
-	// set SourceType (would panic via nil embedded pointer), mirroring the
-	// guard used in UploadImageFromSFS / UploadImageFromHttp.
+	// galImage without GalleryImageProperties: the wrapper must return an error
+	// because SourceType cannot be set, which would cause the download to be
+	// routed incorrectly downstream.
 	galImage := &compute.GalleryImage{}
 	blobImg := &compute.AzureBlobImageProperties{CatalogName: "cat"}
 
 	_, err := c.UploadImageFromAzureStorageBlob(context.Background(), "loc-1", "img-1", galImage, blobImg)
-	require.NoError(t, err)
-	require.Equal(t, 1, fake.callCount)
-
-	require.NotNil(t, fake.gotImage)
-	assert.Nil(t, fake.gotImage.GalleryImageProperties,
-		"GalleryImageProperties must remain nil so the SFS/Blob wrappers skip SourceType assignment")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GalleryImageProperties are required")
+	assert.Equal(t, 0, fake.callCount, "CreateOrUpdate must not be called when properties are nil")
 }

--- a/services/compute/galleryimage/client_test.go
+++ b/services/compute/galleryimage/client_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the Apache v2.0 License.
+
+package galleryimage
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/microsoft/moc-sdk-for-go/services/compute"
+	"github.com/microsoft/moc/rpc/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeInternal captures the args passed to CreateOrUpdate so the wrapper logic
+// in UploadImageFromAzureStorageBlob can be asserted without a real backend.
+type fakeInternal struct {
+	gotLocation  string
+	gotImagePath string
+	gotName      string
+	gotImage     *compute.GalleryImage
+	callCount    int
+
+	createOrUpdateResp *compute.GalleryImage
+	createOrUpdateErr  error
+}
+
+var _ Service = (*fakeInternal)(nil)
+
+func (f *fakeInternal) Get(ctx context.Context, location, name string) (*[]compute.GalleryImage, error) {
+	return nil, nil
+}
+
+func (f *fakeInternal) CreateOrUpdate(ctx context.Context, location, imagePath, name string, img *compute.GalleryImage) (*compute.GalleryImage, error) {
+	f.callCount++
+	f.gotLocation = location
+	f.gotImagePath = imagePath
+	f.gotName = name
+	f.gotImage = img
+	return f.createOrUpdateResp, f.createOrUpdateErr
+}
+
+func (f *fakeInternal) Delete(ctx context.Context, location, name string) error {
+	return nil
+}
+
+func (f *fakeInternal) Precheck(ctx context.Context, location, imagePath string, galleryImages []*compute.GalleryImage) (bool, error) {
+	return true, nil
+}
+
+func TestUploadImageFromAzureStorageBlob_SetsSourceTypeAndEncodesJSON(t *testing.T) {
+	fake := &fakeInternal{}
+	c := &GalleryImageClient{internal: fake}
+
+	blobImg := &compute.AzureBlobImageProperties{
+		CatalogName: "cat",
+		Audience:    "aud",
+		Version:     "1.2.3",
+		ReleaseName: "rel",
+		Parts:       4,
+		Cloud:       "AzurePublicCloud",
+		Endpoint:    "https://account.blob.core.windows.net/",
+	}
+	galImage := &compute.GalleryImage{
+		GalleryImageProperties: &compute.GalleryImageProperties{},
+	}
+
+	_, err := c.UploadImageFromAzureStorageBlob(context.Background(), "loc-1", "img-1", galImage, blobImg)
+	require.NoError(t, err)
+	require.Equal(t, 1, fake.callCount)
+
+	assert.Equal(t, "loc-1", fake.gotLocation)
+	assert.Equal(t, "img-1", fake.gotName)
+	require.NotNil(t, fake.gotImage)
+	assert.Equal(t, common.ImageSource_AZURESTORAGEBLOB_SOURCE, fake.gotImage.SourceType)
+
+	// imagePath must be the JSON-encoded AzureBlobImageProperties.
+	var roundTrip compute.AzureBlobImageProperties
+	require.NoError(t, json.Unmarshal([]byte(fake.gotImagePath), &roundTrip))
+	assert.Equal(t, *blobImg, roundTrip)
+}
+
+func TestUploadImageFromAzureStorageBlob_NilPropertiesDoesNotSetSourceType(t *testing.T) {
+	fake := &fakeInternal{}
+	c := &GalleryImageClient{internal: fake}
+
+	// galImage without GalleryImageProperties: the wrapper must NOT attempt to
+	// set SourceType (would panic via nil embedded pointer), mirroring the
+	// guard used in UploadImageFromSFS / UploadImageFromHttp.
+	galImage := &compute.GalleryImage{}
+	blobImg := &compute.AzureBlobImageProperties{CatalogName: "cat"}
+
+	_, err := c.UploadImageFromAzureStorageBlob(context.Background(), "loc-1", "img-1", galImage, blobImg)
+	require.NoError(t, err)
+	require.Equal(t, 1, fake.callCount)
+
+	require.NotNil(t, fake.gotImage)
+	assert.Nil(t, fake.gotImage.GalleryImageProperties,
+		"GalleryImageProperties must remain nil so the SFS/Blob wrappers skip SourceType assignment")
+}

--- a/services/compute/galleryimage/client_test.go
+++ b/services/compute/galleryimage/client_test.go
@@ -82,18 +82,21 @@ func TestUploadImageFromAzureStorageBlob_SetsSourceTypeAndEncodesJSON(t *testing
 	assert.Equal(t, *blobImg, roundTrip)
 }
 
-func TestUploadImageFromAzureStorageBlob_NilPropertiesReturnsError(t *testing.T) {
+func TestUploadImageFromAzureStorageBlob_NilPropertiesDoesNotSetSourceType(t *testing.T) {
 	fake := &fakeInternal{}
 	c := &GalleryImageClient{internal: fake}
 
-	// galImage without GalleryImageProperties: the wrapper must return an error
-	// because SourceType cannot be set, which would cause the download to be
-	// routed incorrectly downstream.
+	// galImage without GalleryImageProperties: the wrapper must NOT attempt to
+	// set SourceType (would panic via nil embedded pointer), mirroring the
+	// guard used in UploadImageFromSFS / UploadImageFromHttp.
 	galImage := &compute.GalleryImage{}
 	blobImg := &compute.AzureBlobImageProperties{CatalogName: "cat"}
 
 	_, err := c.UploadImageFromAzureStorageBlob(context.Background(), "loc-1", "img-1", galImage, blobImg)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "GalleryImageProperties are required")
-	assert.Equal(t, 0, fake.callCount, "CreateOrUpdate must not be called when properties are nil")
+	require.NoError(t, err)
+	require.Equal(t, 1, fake.callCount)
+
+	require.NotNil(t, fake.gotImage)
+	assert.Nil(t, fake.gotImage.GalleryImageProperties,
+		"GalleryImageProperties must remain nil so the SFS/Blob wrappers skip SourceType assignment")
 }


### PR DESCRIPTION
## Summary

Add SDK support for provisioning gallery images via Azure Storage Blob
download, enabling AGC environments (USSec/USNat) where SFS endpoints
are unreachable.

## Changes

- Add `AzureBlobImageProperties` struct in `services/compute/compute.go`
  — extends `SFSImageProperties` with `Cloud` and `Endpoint` fields
  needed by the azurestorageblob download provider
- Add `UploadImageFromAzureStorageBlob()` method on
  `GalleryImageClient` — follows the existing `UploadImageFromSFS` /
  `UploadImageFromHttp` pattern: marshals properties to JSON, sets
  `SourceType = AZURESTORAGEBLOB_SOURCE`, calls `CreateOrUpdate`

## Related PRs
- [moc: Add AZURESTORAGEBLOB_SOURCE enum](https://github.com/microsoft/moc/pull/431)
- [wssdcloudagent: Update container lifecycle for blob images](https://github.com/microsoft/wssdcloudagent/pull/1722)
- [wssdagent: Add azurestorageblob download dispatch and handler](https://github.com/microsoft/wssdagent/pull/1562)